### PR TITLE
Add button to turn on rotation animation in preview window

### DIFF
--- a/addons/material_maker/preview.gd
+++ b/addons/material_maker/preview.gd
@@ -69,12 +69,12 @@ func _on_Preview2D_gui_input(ev : InputEvent):
 		preview_maximized = !preview_maximized
 		_on_Preview_resized()
 
-func _on_Button_toggled(button_pressed):
+func _on_Background_toggled(button_pressed):
 	emit_signal("show_background_preview", button_pressed)
 
 func on_gui_input(event):
 	if event is InputEventMouseButton:
-		$MaterialPreview/Preview3d/ObjectRotate.stop()
+		$MaterialPreview/Preview3d/ObjectRotate.stop(false)
 		match event.button_index:
 			BUTTON_WHEEL_UP:
 				camera.translation.z *= 1.01 if event.shift else 1.1
@@ -95,3 +95,10 @@ func on_gui_input(event):
 				camera_stand.rotate(camera_basis.y.normalized(), -motion.x)
 			elif event.button_mask & BUTTON_MASK_RIGHT:
 				camera_stand.rotate(camera_basis.z.normalized(), -motion.x)
+
+
+func _on_Rotate_pressed():
+	if $MaterialPreview/Preview3d/ObjectRotate.is_playing():
+		$MaterialPreview/Preview3d/ObjectRotate.stop(false)
+	else:
+		$MaterialPreview/Preview3d/ObjectRotate.play("rotate")

--- a/addons/material_maker/preview.tscn
+++ b/addons/material_maker/preview.tscn
@@ -64,12 +64,24 @@ text = "Epping Forest"
 items = [ "Epping Forest", null, false, -1, null, "Moonless Golf", null, false, -1, null ]
 selected = 0
 
-[node name="Button" type="Button" parent="Config"]
+[node name="Rotate" type="Button" parent="Config"]
+margin_left = 348.0
+margin_right = 368.0
+margin_bottom = 20.0
+rect_pivot_offset = Vector2( -4, 7 )
+hint_tooltip = "Show in main view"
+size_flags_horizontal = 10
+text = "R"
+
+[node name="Background" type="Button" parent="Config"]
 margin_left = 372.0
 margin_right = 395.0
 margin_bottom = 20.0
+grow_horizontal = 2
+grow_vertical = 2
+rect_pivot_offset = Vector2( -4, 7 )
 hint_tooltip = "Show in main view"
-size_flags_horizontal = 10
+size_flags_horizontal = 8
 toggle_mode = true
 text = "O"
 
@@ -87,5 +99,6 @@ size_flags_vertical = 8
 [connection signal="resized" from="." to="." method="_on_Preview_resized"]
 [connection signal="item_selected" from="Config/Model" to="." method="_on_Model_item_selected"]
 [connection signal="item_selected" from="Config/Environment" to="." method="_on_Environment_item_selected"]
-[connection signal="toggled" from="Config/Button" to="." method="_on_Button_toggled"]
+[connection signal="pressed" from="Config/Rotate" to="." method="_on_Rotate_pressed"]
+[connection signal="toggled" from="Config/Background" to="." method="_on_Background_toggled"]
 [connection signal="gui_input" from="Preview2D" to="." method="_on_Preview2D_gui_input"]


### PR DESCRIPTION
Hi, please excuse my code, i'm very new to godot but I thought this would be a very simple addition, just a button that lets you toggle the rotation animation back on again, i found it frustrating that there was no way to do this.  If you like this idea but would prefer the UI works differently, let me know, i'm happy to change things.

![rotate](https://user-images.githubusercontent.com/540820/66922465-6aefc500-f027-11e9-8c61-52d1c271a1bc.gif)
