### PR TITLE
Fix mixed indentation in `gen_switch.gd`

### DIFF
--- a/addons/material_maker/engine/gen_switch.gd
+++ b/addons/material_maker/engine/gen_switch.gd
@@ -13,9 +13,11 @@ func get_type_name():
 	return "Switch"
 
 func get_parameter_defs():
-	return [ { name="outputs", label="Outputs", type="float", min=1, max=5, step=1, default=2 },
-			 { name="choices", label="Choices", type="float", min=2, max=5, step=1, default=2 },
-			 { name="source", label="Source", type="float", min=0, max=1, step=1, default=0 } ]
+	return [
+		{ name="outputs", label="Outputs", type="float", min=1, max=5, step=1, default=2 },
+		{ name="choices", label="Choices", type="float", min=2, max=5, step=1, default=2 },
+		{ name="source", label="Source", type="float", min=0, max=1, step=1, default=0 },
+	]
 
 func get_input_defs():
 	var rv : Array = []
@@ -23,7 +25,7 @@ func get_input_defs():
 		for o in range(parameters.outputs):
 			rv.push_back({ name=PoolByteArray([64+o]).get_string_from_ascii()+str(c), type="rgba" })
 	return rv
-	
+
 func get_output_defs():
 	var rv : Array = []
 	for o in range(parameters.outputs):


### PR DESCRIPTION
Mixed indentation is no longer allowed in Godot's `master` branch.

This change allows Material Maker to run without script errors when using the `master` branch.