### PR TITLE
Implement basic hiDPI support

### DIFF
--- a/addons/material_maker/main_window.gd
+++ b/addons/material_maker/main_window.gd
@@ -41,6 +41,11 @@ const MENU = [
 signal quit
 
 func _ready():
+	# Upscale everything if the display requires it (crude hiDPI support).
+	# This prevents UI elements from being too small on hiDPI displays.
+	if OS.get_screen_dpi() >= 192 and OS.get_screen_size().x >= 2048:
+		get_tree().set_screen_stretch(SceneTree.STRETCH_MODE_DISABLED, SceneTree.STRETCH_ASPECT_IGNORE, Vector2(), 2)
+
 	if !Engine.editor_hint:
 		OS.set_window_title(ProjectSettings.get_setting("application/config/name")+" v"+ProjectSettings.get_setting("application/config/release"))
 	load_recents()

--- a/project.godot
+++ b/project.godot
@@ -167,6 +167,7 @@ gdscript/warnings/unsafe_call_argument=true
 
 window/size/width=1280
 window/size/height=720
+window/dpi/allow_hidpi=true
 
 [logging]
 


### PR DESCRIPTION
This basic implementation simply upscales the viewport if needed. This ensures crisp display regardless of the OS, and ensures OS-specific fallbacks don't interfere with the program.

A proper hiDPI implementation will be needed to have better-looking fonts and rendering.

This partially addresses #8. This PR likely conflicts with #17; feel free to merge either of those first, I'll rebase the other one.