### PR TITLE
Add margins to the window

### DIFF
--- a/addons/material_maker/main_window.tscn
+++ b/addons/material_maker/main_window.tscn
@@ -26,11 +26,15 @@ script = ExtResource( 1 )
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 anchor_right = 1.0
 anchor_bottom = 1.0
+margin_left = 6.0
+margin_top = 6.0
+margin_right = -6.0
+margin_bottom = -6.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="Menu" type="HBoxContainer" parent="VBoxContainer"]
-margin_right = 1280.0
+margin_right = 1268.0
 margin_bottom = 20.0
 
 [node name="File" type="MenuButton" parent="VBoxContainer/Menu"]
@@ -62,19 +66,19 @@ items = [ "User manual", null, 0, false, false, 21, 0, null, "", false, "Report 
 
 [node name="HBoxContainer" type="HSplitContainer" parent="VBoxContainer"]
 margin_top = 24.0
-margin_right = 1280.0
-margin_bottom = 720.0
+margin_right = 1268.0
+margin_bottom = 708.0
 size_flags_vertical = 3
 
 [node name="VBoxContainer" type="VSplitContainer" parent="VBoxContainer/HBoxContainer"]
-margin_right = 314.0
-margin_bottom = 696.0
+margin_right = 311.0
+margin_bottom = 684.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="Library" parent="VBoxContainer/HBoxContainer/VBoxContainer" instance=ExtResource( 2 )]
-margin_right = 314.0
-margin_bottom = 411.0
+margin_right = 311.0
+margin_bottom = 404.0
 size_flags_vertical = 3
 size_flags_stretch_ratio = 1.5
 
@@ -82,14 +86,14 @@ size_flags_stretch_ratio = 1.5
 anchor_left = 0.0
 anchor_right = 0.0
 margin_left = 0.0
-margin_top = 423.0
-margin_right = 314.0
-margin_bottom = 696.0
+margin_top = 416.0
+margin_right = 311.0
+margin_bottom = 684.0
 
 [node name="ProjectsPane" type="Control" parent="VBoxContainer/HBoxContainer"]
-margin_left = 326.0
-margin_right = 1280.0
-margin_bottom = 696.0
+margin_left = 323.0
+margin_right = 1268.0
+margin_bottom = 684.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 size_flags_stretch_ratio = 3.0
@@ -101,7 +105,7 @@ anchor_bottom = 1.0
 stretch = true
 
 [node name="Viewport" type="Viewport" parent="VBoxContainer/HBoxContainer/ProjectsPane/BackgroundPreview"]
-size = Vector2( 954, 696 )
+size = Vector2( 945, 684 )
 handle_input_locally = false
 render_target_update_mode = 0
 
@@ -114,12 +118,14 @@ current = true
 self_modulate = Color( 1, 1, 1, 0 )
 anchor_right = 1.0
 anchor_bottom = 1.0
+margin_right = 5.0
+margin_bottom = 5.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 script = ExtResource( 5 )
 
 [node name="Tabs" type="Tabs" parent="VBoxContainer/HBoxContainer/ProjectsPane/Projects"]
-margin_right = 954.0
+margin_right = 950.0
 margin_bottom = 24.0
 tab_align = 0
 tab_close_display_policy = 1


### PR DESCRIPTION
This prevents text from being next to the window borders, which looks ugly and is difficult to read when in fullscreen mode.

## Preview

### Before

![Before](https://user-images.githubusercontent.com/180032/67011774-7fe45b00-f0f0-11e9-9fc7-c5972fc7facf.png)

### After

![After](https://user-images.githubusercontent.com/180032/67011769-7eb32e00-f0f0-11e9-9fba-aac54949243c.png)