### PR TITLE
Fix recently added mixed indent in `main_window.gd`

### DIFF
--- a/addons/material_maker/main_window.gd
+++ b/addons/material_maker/main_window.gd
@@ -48,12 +48,12 @@ func _ready():
 	if OS.get_name() == "OSX":
 		is_mac = true
 
-  # Upscale everything if the display requires it (crude hiDPI support).
+	# Upscale everything if the display requires it (crude hiDPI support).
 	# This prevents UI elements from being too small on hiDPI displays.
 	if OS.get_screen_dpi() >= 192 and OS.get_screen_size().x >= 2048:
 		get_tree().set_screen_stretch(SceneTree.STRETCH_MODE_DISABLED, SceneTree.STRETCH_ASPECT_IGNORE, Vector2(), 2)
 
-  # Set a minimum window size to prevent UI elements from collapsing on each other.
+	# Set a minimum window size to prevent UI elements from collapsing on each other.
 	# This property is only available in 3.2alpha or later, so use `set()` to fail gracefully if it doesn't exist.
 	OS.set("min_window_size", Vector2(1024, 600))
 


### PR DESCRIPTION
It seems spaces were accidentally added (they weren't in the original PRs though).