### PR TITLE
Improve filtering in the library

### DIFF
--- a/addons/material_maker/library.gd
+++ b/addons/material_maker/library.gd
@@ -4,6 +4,7 @@ extends VBoxContainer
 var libraries = []
 
 onready var tree : Tree = $Tree
+onready var filter_line_edit : LineEdit = $HBoxContainer/Filter
 
 func _ready():
 	tree.set_column_expand(0, true)
@@ -14,6 +15,10 @@ func _ready():
 		add_library("res://addons/material_maker/library/base.json")
 	add_library("user://library/user.json")
 	update_tree()
+
+func _unhandled_input(event : InputEvent) -> void:
+	if event is InputEventKey and event.pressed and event.command and event.scancode == KEY_F:
+		filter_line_edit.grab_focus()
 
 func get_selected_item_name():
 	var tree_item : TreeItem = tree.get_selected()

--- a/addons/material_maker/library.tscn
+++ b/addons/material_maker/library.tscn
@@ -7,22 +7,13 @@
 margin_right = 352.0
 margin_bottom = 423.0
 script = ExtResource( 1 )
-
-[node name="Tree" type="Tree" parent="."]
-margin_right = 352.0
-margin_bottom = 395.0
-rect_min_size = Vector2( 100, 100 )
-size_flags_horizontal = 3
-size_flags_vertical = 3
-columns = 2
-hide_root = true
-select_mode = 1
-script = ExtResource( 2 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
 
 [node name="HBoxContainer" type="HBoxContainer" parent="."]
-margin_top = 399.0
 margin_right = 352.0
-margin_bottom = 423.0
+margin_bottom = 24.0
 size_flags_horizontal = 3
 
 [node name="FilterLabel" type="Label" parent="HBoxContainer"]
@@ -36,4 +27,16 @@ margin_left = 41.0
 margin_right = 352.0
 margin_bottom = 24.0
 size_flags_horizontal = 3
+
+[node name="Tree" type="Tree" parent="."]
+margin_top = 28.0
+margin_right = 352.0
+margin_bottom = 423.0
+rect_min_size = Vector2( 100, 100 )
+size_flags_horizontal = 3
+size_flags_vertical = 3
+columns = 2
+hide_root = true
+select_mode = 1
+script = ExtResource( 2 )
 [connection signal="text_changed" from="HBoxContainer/Filter" to="." method="_on_Filter_text_changed"]


### PR DESCRIPTION
The filter box is now located at the top of the library tree, as most search boxes are placed above the elements they search in.

Pressing Ctrl + F will now focus the filter box as well.