### PR TITLE
Add a .mailmap file

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,2 @@
+Rodolphe Suescun <rodzilla@free.fr>
+jack perkins <jackaperkins@posteo.net>


### PR DESCRIPTION
This fixes duplicate authors when using commands such as `git shortlog`.

[More information on `.mailmap`](https://www.git-scm.com/docs/git-check-mailmap)