### PR TITLE
Enable 16× anisotropic filtering in the 3D preview

### DIFF
--- a/addons/material_maker/engine/gen_material.gd
+++ b/addons/material_maker/engine/gen_material.gd
@@ -87,6 +87,8 @@ func render_textures(renderer : MMGenRenderer):
 				texture = ImageTexture.new()
 				result.copy_to_texture(texture)
 				result.release()
+				# To work, this must be set after calling `copy_to_texture()`
+				texture.flags |= ImageTexture.FLAG_ANISOTROPIC_FILTER
 		elif t.has("ports"):
 			var context : MMGenContext = MMGenContext.new(renderer)
 			var code = []
@@ -109,6 +111,9 @@ func render_textures(renderer : MMGenRenderer):
 			texture = ImageTexture.new()
 			result.copy_to_texture(texture)
 			result.release()
+			# To work, this must be set after calling `copy_to_texture()`
+			texture.flags |= ImageTexture.FLAG_ANISOTROPIC_FILTER
+
 		generated_textures[t.texture] = texture
 
 func update_materials(material_list):

--- a/project.godot
+++ b/project.godot
@@ -179,4 +179,5 @@ file_logging/enable_file_logging=true
 
 [rendering]
 
+quality/filters/anisotropic_filter_level=16
 environment/default_environment="res://default_env.tres"


### PR DESCRIPTION
This improves rendering quality, especially when viewing the texture at an oblique angle.

## Preview

### Before

![Without anisotropic filtering](https://user-images.githubusercontent.com/180032/67151153-c341f380-f2c1-11e9-95bc-b0fa46ded48f.png)

### After

![With anisotropic filtering](https://user-images.githubusercontent.com/180032/67151144-a1487100-f2c1-11e9-8192-79ed6969d53d.png)