### PR TITLE
Tweak texture size limits for consistency, set default size to 1024x1024

### DIFF
--- a/addons/material_maker/engine/gen_buffer.gd
+++ b/addons/material_maker/engine/gen_buffer.gd
@@ -20,7 +20,7 @@ func get_type_name():
 	return "Buffer"
 
 func get_parameter_defs():
-	return [ { name="size", type="size", first=4, last=11, default=4 } ]
+	return [ { name="size", type="size", first=4, last=12, default=4 } ]
 
 func get_input_defs():
 	return [ { name="in", type="rgba" } ]

--- a/addons/material_maker/engine/gen_material.gd
+++ b/addons/material_maker/engine/gen_material.gd
@@ -15,6 +15,15 @@ const TEXTURE_LIST = [
 	{ port=6, texture="depth_texture" }
 ]
 
+# The minimum allowed texture size as a power-of-two exponent
+const TEXTURE_SIZE_MIN = 4  # 16x16
+
+# The maximum allowed texture size as a power-of-two exponent
+const TEXTURE_SIZE_MAX = 12  # 4096x4096
+
+# The default texture size as a power-of-two exponent
+const TEXTURE_SIZE_DEFAULT = 10  # 1024x1024
+
 func _ready():
 	texture_list = TEXTURE_LIST
 	for t in texture_list:
@@ -39,7 +48,7 @@ func get_parameter_defs():
 		{ name="normal_scale", label="Normal", type="float", min=0.0, max=8.0, step=0.05, default=1.0 },
 		{ name="ao_light_affect", label="Ambient occlusion", type="float", min=0.0, max=1.0, step=0.05, default=1.0 },
 		{ name="depth_scale", label="Depth", type="float", min=0.0, max=1.0, step=0.05, default=1.0 },
-		{ name="size", label="Size", type="size", first=7, last=11, default=9 }
+		{ name="size", label="Size", type="size", first=TEXTURE_SIZE_MIN, last=TEXTURE_SIZE_MAX, default=TEXTURE_SIZE_DEFAULT }
 	]
 
 func get_input_defs():
@@ -56,9 +65,9 @@ func get_input_defs():
 func get_image_size():
 	var rv : int
 	if parameters.has("size"):
-		rv = int(pow(2, parameters.size+7))
+		rv = int(pow(2, parameters.size+TEXTURE_SIZE_MIN))
 	else:
-		rv = 512
+		rv = int(pow(2, TEXTURE_SIZE_DEFAULT))
 	return rv
 
 func update_preview():

--- a/addons/material_maker/widgets/node_editor/parameter_size.gd
+++ b/addons/material_maker/widgets/node_editor/parameter_size.gd
@@ -3,7 +3,7 @@ extends HBoxContainer
 
 var size_first = 0
 var size_last = 12
-var size_default = 8
+var size_default = 10
 
 func _ready():
 	update_size_configuration()


### PR DESCRIPTION
- The maximum allowed size is now 4096x4096 for all textures.
- The material texture size can now be set as low as 16x16.
- The default material texture size is now 1024x1024, which matches modern expectations better.

Note that this will change the output size of existing material files. This can be solved by changing the output size and saving the material again.