### PR TITLE
Pretty-print the .ptex JSONs for better diffs in version control

### DIFF
--- a/addons/material_maker/examples/biohazard.ptex
+++ b/addons/material_maker/examples/biohazard.ptex
@@ -1,1 +1,656 @@
-{"connections":[{"from":"pattern_0","from_port":0,"to":"colorize_0","to_port":0},{"from":"colorize_0","from_port":0,"to":"transform_0","to_port":0},{"from":"pattern_0","from_port":0,"to":"colorize_1","to_port":0},{"from":"colorize_1","from_port":0,"to":"transform_1","to_port":0},{"from":"transform_1","from_port":0,"to":"blend_0","to_port":0},{"from":"transform_0","from_port":0,"to":"blend_0","to_port":1},{"from":"transform_2","from_port":0,"to":"blend_1","to_port":1},{"from":"blend_1","from_port":0,"to":"blend_2","to_port":0},{"from":"transform_3","from_port":0,"to":"blend_2","to_port":1},{"from":"pattern_1","from_port":0,"to":"transform_4","to_port":0},{"from":"transform_4","from_port":0,"to":"blend_3","to_port":0},{"from":"blend_0","from_port":0,"to":"blend_3","to_port":1},{"from":"blend_3","from_port":0,"to":"blend_1","to_port":0},{"from":"blend_3","from_port":0,"to":"transform_2","to_port":0},{"from":"blend_3","from_port":0,"to":"transform_3","to_port":0},{"from":"colorize_1","from_port":0,"to":"blend_4","to_port":0},{"from":"colorize_0","from_port":0,"to":"blend_4","to_port":1},{"from":"blend_5","from_port":0,"to":"blend_6","to_port":1},{"from":"blend_2","from_port":0,"to":"colorize_2","to_port":0},{"from":"colorize_2","from_port":0,"to":"blend_5","to_port":0},{"from":"blend_6","from_port":0,"to":"normal_map_0","to_port":0},{"from":"normal_map_0","from_port":0,"to":"Material","to_port":4},{"from":"combine_0","from_port":0,"to":"Material","to_port":0},{"from":"uniform_0","from_port":0,"to":"Material","to_port":1},{"from":"colorize_3","from_port":0,"to":"Material","to_port":2},{"from":"blend_6","from_port":0,"to":"colorize_3","to_port":0},{"from":"colorize_4","from_port":0,"to":"combine_0","to_port":0},{"from":"blend_6","from_port":0,"to":"colorize_4","to_port":0},{"from":"colorize_1","from_port":0,"to":"transform_6","to_port":0},{"from":"blend_7","from_port":0,"to":"blend_6","to_port":0},{"from":"blend_2","from_port":0,"to":"blend_7","to_port":1},{"from":"transform_6","from_port":0,"to":"blend_7","to_port":0},{"from":"blend_4","from_port":0,"to":"blend_5","to_port":1}],"label":"Graph","name":"163","node_position":{"x":0,"y":0},"nodes":[{"name":"transform_3","node_position":{"x":253,"y":237.5},"parameters":{"repeat":false,"rotate":240,"scale_x":1,"scale_y":1,"translate_x":0,"translate_y":0},"type":"transform"},{"name":"pattern_0","node_position":{"x":-463,"y":-41.5},"parameters":{"mix":0,"x_scale":1,"x_wave":0,"y_scale":1,"y_wave":0},"type":"pattern"},{"name":"colorize_4","node_position":{"x":968,"y":12.386353},"parameters":{"gradient":{"points":[{"a":1,"b":0,"g":0,"pos":0,"r":0},{"a":1,"b":1,"g":1,"pos":0.090909,"r":1}],"type":"Gradient"}},"type":"colorize"},{"name":"pattern_1","node_position":{"x":218.5,"y":-420.25},"parameters":{"mix":0,"x_scale":1,"x_wave":2,"y_scale":1,"y_wave":2},"type":"pattern"},{"name":"Material","node_position":{"x":1320,"y":-22},"parameters":{"albedo_color":{"a":1,"b":1,"g":1,"r":1,"type":"Color"},"ao_light_affect":1,"depth_scale":1,"emission_energy":1,"metallic":1,"normal_scale":1,"resolution":1,"roughness":1,"size":11},"type":"material"},{"name":"transform_4","node_position":{"x":459.5,"y":-471.25},"parameters":{"repeat":false,"rotate":0,"scale_x":0.05,"scale_y":2,"translate_x":-0.015,"translate_y":-0.15},"type":"transform"},{"name":"transform_1","node_position":{"x":21,"y":-170.5},"parameters":{"repeat":false,"rotate":0,"scale_x":1,"scale_y":1,"translate_x":0,"translate_y":-0.25},"type":"transform"},{"name":"transform_0","node_position":{"x":21,"y":43.5},"parameters":{"repeat":false,"rotate":0,"scale_x":1,"scale_y":1,"translate_x":0,"translate_y":-0.22},"type":"transform"},{"name":"blend_0","node_position":{"x":300,"y":-228.5},"parameters":{"amount":1,"blend_type":11},"type":"blend"},{"name":"transform_2","node_position":{"x":253,"y":26.5},"parameters":{"repeat":false,"rotate":120,"scale_x":1,"scale_y":1,"translate_x":0,"translate_y":0},"type":"transform"},{"name":"blend_3","node_position":{"x":554.5,"y":-231.25},"parameters":{"amount":1,"blend_type":11},"type":"blend"},{"name":"colorize_2","node_position":{"x":674.5,"y":238.75},"parameters":{"gradient":{"points":[{"a":1,"b":0,"g":0,"pos":0,"r":0},{"a":1,"b":1,"g":1,"pos":0.072727,"r":1}],"type":"Gradient"}},"type":"colorize"},{"name":"colorize_0","node_position":{"x":-216,"y":-50.5},"parameters":{"gradient":{"points":[{"a":1,"b":0,"g":0,"pos":0.581818,"r":0},{"a":1,"b":1,"g":1,"pos":0.645455,"r":1}],"type":"Gradient"}},"type":"colorize"},{"name":"colorize_1","node_position":{"x":-215,"y":-118.5},"parameters":{"gradient":{"points":[{"a":1,"b":0,"g":0,"pos":0.663636,"r":0},{"a":1,"b":1,"g":1,"pos":0.7,"r":1}],"type":"Gradient"}},"type":"colorize"},{"name":"blend_5","node_position":{"x":846.5,"y":338.75},"parameters":{"amount":1,"blend_type":11},"type":"blend"},{"name":"blend_6","node_position":{"x":887.5,"y":185.75},"parameters":{"amount":1,"blend_type":3},"type":"blend"},{"name":"blend_1","node_position":{"x":491,"y":51.5},"parameters":{"amount":1,"blend_type":3},"type":"blend"},{"name":"blend_2","node_position":{"x":487,"y":168.75},"parameters":{"amount":1,"blend_type":3},"type":"blend"},{"name":"transform_6","node_position":{"x":735,"y":-110.613647},"parameters":{"repeat":false,"rotate":0,"scale_x":0.2,"scale_y":0.2,"translate_x":0,"translate_y":0},"type":"transform"},{"name":"blend_7","node_position":{"x":731,"y":94.386353},"parameters":{"amount":1,"blend_type":11},"type":"blend"},{"name":"combine_0","node_position":{"x":1099.5,"y":-77.25},"parameters":{"color":{"a":1,"b":1,"g":1,"r":1,"type":"Color"},"name":0},"type":"combine"},{"name":"uniform_0","node_position":{"x":1138.5,"y":23.75},"parameters":{"color":{"a":1,"b":0,"g":0,"r":0,"type":"Color"}},"type":"uniform"},{"name":"blend_4","node_position":{"x":484.5,"y":309.75},"parameters":{"amount":1,"blend_type":11},"type":"blend"},{"name":"colorize_3","node_position":{"x":1094.04541,"y":85.386353},"parameters":{"gradient":{"points":[{"a":1,"b":1,"g":1,"pos":0,"r":1},{"a":1,"b":0,"g":0,"pos":0.118182,"r":0}],"type":"Gradient"}},"type":"colorize"},{"name":"normal_map_0","node_position":{"x":1113.5,"y":184.75},"parameters":{"amount":0.5,"param0":11,"param1":0.99,"size":2},"type":"normal_map"}],"parameters":{},"type":"graph"}
+{
+	"connections": [
+		{
+			"from": "pattern_0",
+			"from_port": 0,
+			"to": "colorize_0",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_0",
+			"from_port": 0,
+			"to": "transform_0",
+			"to_port": 0
+		},
+		{
+			"from": "pattern_0",
+			"from_port": 0,
+			"to": "colorize_1",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_1",
+			"from_port": 0,
+			"to": "transform_1",
+			"to_port": 0
+		},
+		{
+			"from": "transform_1",
+			"from_port": 0,
+			"to": "blend_0",
+			"to_port": 0
+		},
+		{
+			"from": "transform_0",
+			"from_port": 0,
+			"to": "blend_0",
+			"to_port": 1
+		},
+		{
+			"from": "transform_2",
+			"from_port": 0,
+			"to": "blend_1",
+			"to_port": 1
+		},
+		{
+			"from": "blend_1",
+			"from_port": 0,
+			"to": "blend_2",
+			"to_port": 0
+		},
+		{
+			"from": "transform_3",
+			"from_port": 0,
+			"to": "blend_2",
+			"to_port": 1
+		},
+		{
+			"from": "pattern_1",
+			"from_port": 0,
+			"to": "transform_4",
+			"to_port": 0
+		},
+		{
+			"from": "transform_4",
+			"from_port": 0,
+			"to": "blend_3",
+			"to_port": 0
+		},
+		{
+			"from": "blend_0",
+			"from_port": 0,
+			"to": "blend_3",
+			"to_port": 1
+		},
+		{
+			"from": "blend_3",
+			"from_port": 0,
+			"to": "blend_1",
+			"to_port": 0
+		},
+		{
+			"from": "blend_3",
+			"from_port": 0,
+			"to": "transform_2",
+			"to_port": 0
+		},
+		{
+			"from": "blend_3",
+			"from_port": 0,
+			"to": "transform_3",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_1",
+			"from_port": 0,
+			"to": "blend_4",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_0",
+			"from_port": 0,
+			"to": "blend_4",
+			"to_port": 1
+		},
+		{
+			"from": "blend_5",
+			"from_port": 0,
+			"to": "blend_6",
+			"to_port": 1
+		},
+		{
+			"from": "blend_2",
+			"from_port": 0,
+			"to": "colorize_2",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_2",
+			"from_port": 0,
+			"to": "blend_5",
+			"to_port": 0
+		},
+		{
+			"from": "blend_6",
+			"from_port": 0,
+			"to": "normal_map_0",
+			"to_port": 0
+		},
+		{
+			"from": "normal_map_0",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 4
+		},
+		{
+			"from": "combine_0",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 0
+		},
+		{
+			"from": "uniform_0",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 1
+		},
+		{
+			"from": "colorize_3",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 2
+		},
+		{
+			"from": "blend_6",
+			"from_port": 0,
+			"to": "colorize_3",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_4",
+			"from_port": 0,
+			"to": "combine_0",
+			"to_port": 0
+		},
+		{
+			"from": "blend_6",
+			"from_port": 0,
+			"to": "colorize_4",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_1",
+			"from_port": 0,
+			"to": "transform_6",
+			"to_port": 0
+		},
+		{
+			"from": "blend_7",
+			"from_port": 0,
+			"to": "blend_6",
+			"to_port": 0
+		},
+		{
+			"from": "blend_2",
+			"from_port": 0,
+			"to": "blend_7",
+			"to_port": 1
+		},
+		{
+			"from": "transform_6",
+			"from_port": 0,
+			"to": "blend_7",
+			"to_port": 0
+		},
+		{
+			"from": "blend_4",
+			"from_port": 0,
+			"to": "blend_5",
+			"to_port": 1
+		}
+	],
+	"label": "Graph",
+	"name": "163",
+	"node_position": {
+		"x": 0,
+		"y": 0
+	},
+	"nodes": [
+		{
+			"name": "transform_3",
+			"node_position": {
+				"x": 253,
+				"y": 237.5
+			},
+			"parameters": {
+				"repeat": false,
+				"rotate": 240,
+				"scale_x": 1,
+				"scale_y": 1,
+				"translate_x": 0,
+				"translate_y": 0
+			},
+			"type": "transform"
+		},
+		{
+			"name": "pattern_0",
+			"node_position": {
+				"x": -463,
+				"y": -41.5
+			},
+			"parameters": {
+				"mix": 0,
+				"x_scale": 1,
+				"x_wave": 0,
+				"y_scale": 1,
+				"y_wave": 0
+			},
+			"type": "pattern"
+		},
+		{
+			"name": "colorize_4",
+			"node_position": {
+				"x": 968,
+				"y": 12.386353
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0,
+							"r": 0
+						},
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0.090909,
+							"r": 1
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "pattern_1",
+			"node_position": {
+				"x": 218.5,
+				"y": -420.25
+			},
+			"parameters": {
+				"mix": 0,
+				"x_scale": 1,
+				"x_wave": 2,
+				"y_scale": 1,
+				"y_wave": 2
+			},
+			"type": "pattern"
+		},
+		{
+			"name": "Material",
+			"node_position": {
+				"x": 1320,
+				"y": -22
+			},
+			"parameters": {
+				"albedo_color": {
+					"a": 1,
+					"b": 1,
+					"g": 1,
+					"r": 1,
+					"type": "Color"
+				},
+				"ao_light_affect": 1,
+				"depth_scale": 1,
+				"emission_energy": 1,
+				"metallic": 1,
+				"normal_scale": 1,
+				"resolution": 1,
+				"roughness": 1,
+				"size": 11
+			},
+			"type": "material"
+		},
+		{
+			"name": "transform_4",
+			"node_position": {
+				"x": 459.5,
+				"y": -471.25
+			},
+			"parameters": {
+				"repeat": false,
+				"rotate": 0,
+				"scale_x": 0.05,
+				"scale_y": 2,
+				"translate_x": -0.015,
+				"translate_y": -0.15
+			},
+			"type": "transform"
+		},
+		{
+			"name": "transform_1",
+			"node_position": {
+				"x": 21,
+				"y": -170.5
+			},
+			"parameters": {
+				"repeat": false,
+				"rotate": 0,
+				"scale_x": 1,
+				"scale_y": 1,
+				"translate_x": 0,
+				"translate_y": -0.25
+			},
+			"type": "transform"
+		},
+		{
+			"name": "transform_0",
+			"node_position": {
+				"x": 21,
+				"y": 43.5
+			},
+			"parameters": {
+				"repeat": false,
+				"rotate": 0,
+				"scale_x": 1,
+				"scale_y": 1,
+				"translate_x": 0,
+				"translate_y": -0.22
+			},
+			"type": "transform"
+		},
+		{
+			"name": "blend_0",
+			"node_position": {
+				"x": 300,
+				"y": -228.5
+			},
+			"parameters": {
+				"amount": 1,
+				"blend_type": 11
+			},
+			"type": "blend"
+		},
+		{
+			"name": "transform_2",
+			"node_position": {
+				"x": 253,
+				"y": 26.5
+			},
+			"parameters": {
+				"repeat": false,
+				"rotate": 120,
+				"scale_x": 1,
+				"scale_y": 1,
+				"translate_x": 0,
+				"translate_y": 0
+			},
+			"type": "transform"
+		},
+		{
+			"name": "blend_3",
+			"node_position": {
+				"x": 554.5,
+				"y": -231.25
+			},
+			"parameters": {
+				"amount": 1,
+				"blend_type": 11
+			},
+			"type": "blend"
+		},
+		{
+			"name": "colorize_2",
+			"node_position": {
+				"x": 674.5,
+				"y": 238.75
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0,
+							"r": 0
+						},
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0.072727,
+							"r": 1
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "colorize_0",
+			"node_position": {
+				"x": -216,
+				"y": -50.5
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0.581818,
+							"r": 0
+						},
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0.645455,
+							"r": 1
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "colorize_1",
+			"node_position": {
+				"x": -215,
+				"y": -118.5
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0.663636,
+							"r": 0
+						},
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0.7,
+							"r": 1
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "blend_5",
+			"node_position": {
+				"x": 846.5,
+				"y": 338.75
+			},
+			"parameters": {
+				"amount": 1,
+				"blend_type": 11
+			},
+			"type": "blend"
+		},
+		{
+			"name": "blend_6",
+			"node_position": {
+				"x": 887.5,
+				"y": 185.75
+			},
+			"parameters": {
+				"amount": 1,
+				"blend_type": 3
+			},
+			"type": "blend"
+		},
+		{
+			"name": "blend_1",
+			"node_position": {
+				"x": 491,
+				"y": 51.5
+			},
+			"parameters": {
+				"amount": 1,
+				"blend_type": 3
+			},
+			"type": "blend"
+		},
+		{
+			"name": "blend_2",
+			"node_position": {
+				"x": 487,
+				"y": 168.75
+			},
+			"parameters": {
+				"amount": 1,
+				"blend_type": 3
+			},
+			"type": "blend"
+		},
+		{
+			"name": "transform_6",
+			"node_position": {
+				"x": 735,
+				"y": -110.613647
+			},
+			"parameters": {
+				"repeat": false,
+				"rotate": 0,
+				"scale_x": 0.2,
+				"scale_y": 0.2,
+				"translate_x": 0,
+				"translate_y": 0
+			},
+			"type": "transform"
+		},
+		{
+			"name": "blend_7",
+			"node_position": {
+				"x": 731,
+				"y": 94.386353
+			},
+			"parameters": {
+				"amount": 1,
+				"blend_type": 11
+			},
+			"type": "blend"
+		},
+		{
+			"name": "combine_0",
+			"node_position": {
+				"x": 1099.5,
+				"y": -77.25
+			},
+			"parameters": {
+				"color": {
+					"a": 1,
+					"b": 1,
+					"g": 1,
+					"r": 1,
+					"type": "Color"
+				},
+				"name": 0
+			},
+			"type": "combine"
+		},
+		{
+			"name": "uniform_0",
+			"node_position": {
+				"x": 1138.5,
+				"y": 23.75
+			},
+			"parameters": {
+				"color": {
+					"a": 1,
+					"b": 0,
+					"g": 0,
+					"r": 0,
+					"type": "Color"
+				}
+			},
+			"type": "uniform"
+		},
+		{
+			"name": "blend_4",
+			"node_position": {
+				"x": 484.5,
+				"y": 309.75
+			},
+			"parameters": {
+				"amount": 1,
+				"blend_type": 11
+			},
+			"type": "blend"
+		},
+		{
+			"name": "colorize_3",
+			"node_position": {
+				"x": 1094.04541,
+				"y": 85.386353
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0,
+							"r": 1
+						},
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0.118182,
+							"r": 0
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "normal_map_0",
+			"node_position": {
+				"x": 1113.5,
+				"y": 184.75
+			},
+			"parameters": {
+				"amount": 0.5,
+				"param0": 0,
+				"param1": 11,
+				"param2": 1,
+				"size": 2
+			},
+			"type": "normal_map"
+		}
+	],
+	"parameters": {
+
+	},
+	"type": "graph"
+}

--- a/addons/material_maker/examples/brick_rotated.ptex
+++ b/addons/material_maker/examples/brick_rotated.ptex
@@ -1,1 +1,334 @@
-{"connections":[{"from":"bricks","from_port":2,"to":"transform","to_port":1},{"from":"bricks","from_port":3,"to":"transform","to_port":2},{"from":"bricks","from_port":0,"to":"blend","to_port":1},{"from":"transform","from_port":0,"to":"blend","to_port":0},{"from":"pattern","from_port":0,"to":"transform","to_port":0},{"from":"bricks","from_port":1,"to":"transform","to_port":3},{"from":"blend","from_port":0,"to":"colorize","to_port":0},{"from":"colorize","from_port":0,"to":"Material","to_port":6},{"from":"blend","from_port":0,"to":"normal_map","to_port":0},{"from":"normal_map","from_port":0,"to":"Material","to_port":4}],"label":"Graph","name":"47","node_position":{"x":0,"y":0},"nodes":[{"name":"Material","node_position":{"x":70,"y":113},"parameters":{"albedo_color":{"a":1,"b":1,"g":1,"r":1,"type":"Color"},"ao_light_affect":1,"depth_scale":1,"emission_energy":1,"metallic":1,"normal_scale":1,"roughness":1,"size":11},"type":"material"},{"name":"bricks","node_position":{"x":-549.5,"y":-120.5},"parameters":{"bevel":0.1,"columns":3,"mortar":0.1,"pattern":0,"repeat":1,"row_offset":0.5,"rows":6},"shader_model":{"code":"vec4 $(name_uv) = $(name)_xyzw($(uv));\n","global":"vec4 brick(vec2 uv, vec2 bmin, vec2 bmax, float mortar, float bevel) {\n\tfloat color;\n\tvec2 c1 = (uv-bmin-vec2(mortar))/bevel;\n\tvec2 c2 = (bmax-uv-vec2(mortar))/bevel;\n\tvec2 c = min(c1, c2);\n\tcolor = clamp(min(c.x, c.y), 0.0, 1.0);\n\tvec2 tiled_brick_pos = mod(bmin, vec2(1.0, 1.0));\n\treturn vec4(color, 0.5*(bmin+bmax), tiled_brick_pos.x+7.0*tiled_brick_pos.y);\n}\n\nvec4 bricks_rb(vec2 uv, vec2 count, float repeat, float offset, float mortar, float bevel) {\n\tcount *= repeat;\n\tmortar /= max(count.x, count.y);\n\tbevel /= max(count.x, count.y);\n\tfloat x_offset = offset*step(0.5, fract(uv.y*count.y*0.5));\n\tvec2 bmin = floor(vec2(uv.x*count.x-x_offset, uv.y*count.y));\n\tbmin.x += x_offset;\n\tbmin /= count;\n\treturn brick(uv, bmin, bmin+vec2(1.0)/count, mortar, bevel);\n}\n\nvec4 bricks_rb2(vec2 uv, vec2 count, float repeat, float offset, float mortar, float bevel) {\n\tcount *= repeat;\n\tmortar /= max(2.0*count.x, count.y);\n\tbevel /= max(2.0*count.x, count.y);\n\tfloat x_offset = offset*step(0.5, fract(uv.y*count.y*0.5));\n\tcount.x = count.x*(1.0+step(0.5, fract(uv.y*count.y*0.5)));\n\tvec2 bmin = floor(vec2(uv.x*count.x-x_offset, uv.y*count.y));\n\tbmin.x += x_offset;\n\tbmin /= count;\n\treturn brick(uv, bmin, bmin+vec2(1.0)/count, mortar, bevel);\n}\n\nvec4 bricks_hb(vec2 uv, vec2 count, float repeat, float offset, float mortar, float bevel) {\n\tfloat pc = count.x+count.y;\n\tfloat c = pc*repeat;\n\tmortar /= c;\n\tbevel /= c;\n\tvec2 corner = floor(uv*c);\n\tfloat cdiff = mod(corner.x-corner.y, pc);\n\tif (cdiff < count.x) {\n\t\treturn brick(uv, (corner-vec2(cdiff, 0.0))/c, (corner-vec2(cdiff, 0.0)+vec2(count.x, 1.0))/c, mortar, bevel);\n\t} else {\n\t\treturn brick(uv, (corner-vec2(0.0, pc-cdiff-1.0))/c, (corner-vec2(0.0, pc-cdiff-1.0)+vec2(1.0, count.y))/c, mortar, bevel);\n\t}\n}\n\nvec4 bricks_bw(vec2 uv, vec2 count, float repeat, float offset, float mortar, float bevel) {\n\tvec2 c = 2.0*count*repeat;\n\tfloat mc = max(c.x, c.y);\n\tmortar /= mc;\n\tbevel /= mc;\n\tvec2 corner1 = floor(uv*c);\n\tvec2 corner2 = count*floor(repeat*2.0*uv);\n\tfloat cdiff = mod(dot(floor(repeat*2.0*uv), vec2(1.0)), 2.0);\n\tvec2 corner;\n\tvec2 size;\n\tif (cdiff == 0.0) {\n\t\tcorner = vec2(corner1.x, corner2.y);\n\t\tsize = vec2(1.0, count.y);\n\t} else {\n\t\tcorner = vec2(corner2.x, corner1.y);\n\t\tsize = vec2(count.x, 1.0);\n\t}\n\treturn brick(uv, corner/c, (corner+size)/c, mortar, bevel);\n}\n\nvec4 bricks_sb(vec2 uv, vec2 count, float repeat, float offset, float mortar, float bevel) {\n\tvec2 c = (count+vec2(1.0))*repeat;\n\tfloat mc = max(c.x, c.y);\n\tmortar /= mc;\n\tbevel /= mc;\n\tvec2 corner1 = floor(uv*c);\n\tvec2 corner2 = (count+vec2(1.0))*floor(repeat*uv);\n\tvec2 rcorner = corner1 - corner2;\n\tvec2 corner;\n\tvec2 size;\n\tif (rcorner.x == 0.0 && rcorner.y < count.y) {\n\t\tcorner = corner2;\n\t\tsize = vec2(1.0, count.y);\n\t} else if (rcorner.y == 0.0) {\n\t\tcorner = corner2+vec2(1.0, 0.0);\n\t\tsize = vec2(count.x, 1.0);\n\t} else if (rcorner.x == count.x) {\n\t\tcorner = corner2+vec2(count.x, 1.0);\n\t\tsize = vec2(1.0, count.y);\n\t} else if (rcorner.y == count.y) {\n\t\tcorner = corner2+vec2(0.0, count.y);\n\t\tsize = vec2(count.x, 1.0);\n\t} else {\n\t\tcorner = corner2+vec2(1.0);\n\t\tsize = vec2(count.x-1.0, count.y-1.0);\n\t}\n\treturn brick(uv, corner/c, (corner+size)/c, mortar, bevel);\n}","inputs":[],"instance":"vec4 $(name)_xyzw(vec2 uv) {\n    return bricks_$(pattern)(uv, vec2($(columns), $(rows)), $(repeat), $(row_offset), $(mortar), max(0.001, $(bevel)));\n}","name":"Bricks","outputs":[{"f":"$(name_uv).x","type":"f"},{"rgb":"rand3(vec2($(name_uv).w, $(seed)))","type":"rgb"},{"f":"$(name_uv).y","type":"f"},{"f":"$(name_uv).z","type":"f"}],"parameters":[{"default":0,"label":"","name":"pattern","type":"enum","values":[{"name":"Running bond","value":"rb"},{"name":"Running bond (2)","value":"rb2"},{"name":"HerringBone","value":"hb"},{"name":"Basket weave","value":"bw"},{"name":"Spanish bond","value":"sb"}]},{"default":1,"label":"Repeat:","max":8,"min":1,"name":"repeat","step":1,"type":"float","widget":"spinbox"},{"default":6,"label":"Rows:","max":64,"min":1,"name":"rows","step":1,"type":"float","widget":"spinbox"},{"default":3,"label":"Columns:","max":64,"min":1,"name":"columns","step":1,"type":"float","widget":"spinbox"},{"default":0.5,"label":"Offset:","max":1,"min":0,"name":"row_offset","step":0,"type":"float"},{"default":0.1,"label":"Mortar:","max":0.5,"min":0,"name":"mortar","step":0,"type":"float"},{"default":0.1,"label":"Bevel:","max":0.5,"min":0,"name":"bevel","step":0,"type":"float"}]},"type":"shader"},{"name":"blend","node_position":{"x":-286.5,"y":14.5},"parameters":{"amount":1,"blend_type":2},"type":"blend"},{"name":"pattern","node_position":{"x":-547.5,"y":-227.068176},"parameters":{"mix":0,"x_scale":1,"x_wave":3,"y_scale":0,"y_wave":4},"type":"pattern"},{"name":"colorize","node_position":{"x":-10.209106,"y":-146.068176},"parameters":{"gradient":{"points":[{"a":1,"b":1,"g":1,"pos":0,"r":1},{"a":1,"b":0,"g":0,"pos":1,"r":0}],"type":"Gradient"}},"type":"colorize"},{"name":"transform","node_position":{"x":-258.5,"y":-196.5},"parameters":{"repeat":false,"rotate":360,"scale_x":1,"scale_y":1,"translate_x":0.5,"translate_y":0.5},"type":"transform"},{"name":"comment","node_position":{"x":-391.274048,"y":165.542206},"parameters":{"size":4},"size":{"x":280,"y":85},"text":"This example shows how to use the 3rd and 4th outputs of the bricks node to get the center of each brick.","type":"comment"},{"name":"normal_map","node_position":{"x":14.29071,"y":-40.645294},"parameters":{"param0":11,"param1":0.995},"type":"normal_map"}],"parameters":{},"type":"graph"}
+{
+	"connections": [
+		{
+			"from": "bricks",
+			"from_port": 2,
+			"to": "transform",
+			"to_port": 1
+		},
+		{
+			"from": "bricks",
+			"from_port": 3,
+			"to": "transform",
+			"to_port": 2
+		},
+		{
+			"from": "bricks",
+			"from_port": 0,
+			"to": "blend",
+			"to_port": 1
+		},
+		{
+			"from": "transform",
+			"from_port": 0,
+			"to": "blend",
+			"to_port": 0
+		},
+		{
+			"from": "pattern",
+			"from_port": 0,
+			"to": "transform",
+			"to_port": 0
+		},
+		{
+			"from": "bricks",
+			"from_port": 1,
+			"to": "transform",
+			"to_port": 3
+		},
+		{
+			"from": "blend",
+			"from_port": 0,
+			"to": "colorize",
+			"to_port": 0
+		},
+		{
+			"from": "colorize",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 6
+		},
+		{
+			"from": "blend",
+			"from_port": 0,
+			"to": "normal_map",
+			"to_port": 0
+		},
+		{
+			"from": "normal_map",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 4
+		}
+	],
+	"label": "Graph",
+	"name": "47",
+	"node_position": {
+		"x": 0,
+		"y": 0
+	},
+	"nodes": [
+		{
+			"name": "Material",
+			"node_position": {
+				"x": 70,
+				"y": 113
+			},
+			"parameters": {
+				"albedo_color": {
+					"a": 1,
+					"b": 1,
+					"g": 1,
+					"r": 1,
+					"type": "Color"
+				},
+				"ao_light_affect": 1,
+				"depth_scale": 1,
+				"emission_energy": 1,
+				"metallic": 1,
+				"normal_scale": 1,
+				"roughness": 1,
+				"size": 11
+			},
+			"type": "material"
+		},
+		{
+			"name": "bricks",
+			"node_position": {
+				"x": -549.5,
+				"y": -120.5
+			},
+			"parameters": {
+				"bevel": 0.1,
+				"columns": 3,
+				"mortar": 0.1,
+				"pattern": 0,
+				"repeat": 1,
+				"row_offset": 0.5,
+				"rows": 6
+			},
+			"shader_model": {
+				"code": "vec4 $(name_uv) = $(name)_xyzw($(uv));\n",
+				"global": "vec4 brick(vec2 uv, vec2 bmin, vec2 bmax, float mortar, float bevel) {\n\tfloat color;\n\tvec2 c1 = (uv-bmin-vec2(mortar))/bevel;\n\tvec2 c2 = (bmax-uv-vec2(mortar))/bevel;\n\tvec2 c = min(c1, c2);\n\tcolor = clamp(min(c.x, c.y), 0.0, 1.0);\n\tvec2 tiled_brick_pos = mod(bmin, vec2(1.0, 1.0));\n\treturn vec4(color, 0.5*(bmin+bmax), tiled_brick_pos.x+7.0*tiled_brick_pos.y);\n}\n\nvec4 bricks_rb(vec2 uv, vec2 count, float repeat, float offset, float mortar, float bevel) {\n\tcount *= repeat;\n\tmortar /= max(count.x, count.y);\n\tbevel /= max(count.x, count.y);\n\tfloat x_offset = offset*step(0.5, fract(uv.y*count.y*0.5));\n\tvec2 bmin = floor(vec2(uv.x*count.x-x_offset, uv.y*count.y));\n\tbmin.x += x_offset;\n\tbmin /= count;\n\treturn brick(uv, bmin, bmin+vec2(1.0)/count, mortar, bevel);\n}\n\nvec4 bricks_rb2(vec2 uv, vec2 count, float repeat, float offset, float mortar, float bevel) {\n\tcount *= repeat;\n\tmortar /= max(2.0*count.x, count.y);\n\tbevel /= max(2.0*count.x, count.y);\n\tfloat x_offset = offset*step(0.5, fract(uv.y*count.y*0.5));\n\tcount.x = count.x*(1.0+step(0.5, fract(uv.y*count.y*0.5)));\n\tvec2 bmin = floor(vec2(uv.x*count.x-x_offset, uv.y*count.y));\n\tbmin.x += x_offset;\n\tbmin /= count;\n\treturn brick(uv, bmin, bmin+vec2(1.0)/count, mortar, bevel);\n}\n\nvec4 bricks_hb(vec2 uv, vec2 count, float repeat, float offset, float mortar, float bevel) {\n\tfloat pc = count.x+count.y;\n\tfloat c = pc*repeat;\n\tmortar /= c;\n\tbevel /= c;\n\tvec2 corner = floor(uv*c);\n\tfloat cdiff = mod(corner.x-corner.y, pc);\n\tif (cdiff < count.x) {\n\t\treturn brick(uv, (corner-vec2(cdiff, 0.0))/c, (corner-vec2(cdiff, 0.0)+vec2(count.x, 1.0))/c, mortar, bevel);\n\t} else {\n\t\treturn brick(uv, (corner-vec2(0.0, pc-cdiff-1.0))/c, (corner-vec2(0.0, pc-cdiff-1.0)+vec2(1.0, count.y))/c, mortar, bevel);\n\t}\n}\n\nvec4 bricks_bw(vec2 uv, vec2 count, float repeat, float offset, float mortar, float bevel) {\n\tvec2 c = 2.0*count*repeat;\n\tfloat mc = max(c.x, c.y);\n\tmortar /= mc;\n\tbevel /= mc;\n\tvec2 corner1 = floor(uv*c);\n\tvec2 corner2 = count*floor(repeat*2.0*uv);\n\tfloat cdiff = mod(dot(floor(repeat*2.0*uv), vec2(1.0)), 2.0);\n\tvec2 corner;\n\tvec2 size;\n\tif (cdiff == 0.0) {\n\t\tcorner = vec2(corner1.x, corner2.y);\n\t\tsize = vec2(1.0, count.y);\n\t} else {\n\t\tcorner = vec2(corner2.x, corner1.y);\n\t\tsize = vec2(count.x, 1.0);\n\t}\n\treturn brick(uv, corner/c, (corner+size)/c, mortar, bevel);\n}\n\nvec4 bricks_sb(vec2 uv, vec2 count, float repeat, float offset, float mortar, float bevel) {\n\tvec2 c = (count+vec2(1.0))*repeat;\n\tfloat mc = max(c.x, c.y);\n\tmortar /= mc;\n\tbevel /= mc;\n\tvec2 corner1 = floor(uv*c);\n\tvec2 corner2 = (count+vec2(1.0))*floor(repeat*uv);\n\tvec2 rcorner = corner1 - corner2;\n\tvec2 corner;\n\tvec2 size;\n\tif (rcorner.x == 0.0 && rcorner.y < count.y) {\n\t\tcorner = corner2;\n\t\tsize = vec2(1.0, count.y);\n\t} else if (rcorner.y == 0.0) {\n\t\tcorner = corner2+vec2(1.0, 0.0);\n\t\tsize = vec2(count.x, 1.0);\n\t} else if (rcorner.x == count.x) {\n\t\tcorner = corner2+vec2(count.x, 1.0);\n\t\tsize = vec2(1.0, count.y);\n\t} else if (rcorner.y == count.y) {\n\t\tcorner = corner2+vec2(0.0, count.y);\n\t\tsize = vec2(count.x, 1.0);\n\t} else {\n\t\tcorner = corner2+vec2(1.0);\n\t\tsize = vec2(count.x-1.0, count.y-1.0);\n\t}\n\treturn brick(uv, corner/c, (corner+size)/c, mortar, bevel);\n}",
+				"inputs": [
+
+				],
+				"instance": "vec4 $(name)_xyzw(vec2 uv) {\n    return bricks_$(pattern)(uv, vec2($(columns), $(rows)), $(repeat), $(row_offset), $(mortar), max(0.001, $(bevel)));\n}",
+				"name": "Bricks",
+				"outputs": [
+					{
+						"f": "$(name_uv).x",
+						"type": "f"
+					},
+					{
+						"rgb": "rand3(vec2($(name_uv).w, $(seed)))",
+						"type": "rgb"
+					},
+					{
+						"f": "$(name_uv).y",
+						"type": "f"
+					},
+					{
+						"f": "$(name_uv).z",
+						"type": "f"
+					}
+				],
+				"parameters": [
+					{
+						"default": 0,
+						"label": "",
+						"name": "pattern",
+						"type": "enum",
+						"values": [
+							{
+								"name": "Running bond",
+								"value": "rb"
+							},
+							{
+								"name": "Running bond (2)",
+								"value": "rb2"
+							},
+							{
+								"name": "HerringBone",
+								"value": "hb"
+							},
+							{
+								"name": "Basket weave",
+								"value": "bw"
+							},
+							{
+								"name": "Spanish bond",
+								"value": "sb"
+							}
+						]
+					},
+					{
+						"default": 1,
+						"label": "Repeat:",
+						"max": 8,
+						"min": 1,
+						"name": "repeat",
+						"step": 1,
+						"type": "float",
+						"widget": "spinbox"
+					},
+					{
+						"default": 6,
+						"label": "Rows:",
+						"max": 64,
+						"min": 1,
+						"name": "rows",
+						"step": 1,
+						"type": "float",
+						"widget": "spinbox"
+					},
+					{
+						"default": 3,
+						"label": "Columns:",
+						"max": 64,
+						"min": 1,
+						"name": "columns",
+						"step": 1,
+						"type": "float",
+						"widget": "spinbox"
+					},
+					{
+						"default": 0.5,
+						"label": "Offset:",
+						"max": 1,
+						"min": 0,
+						"name": "row_offset",
+						"step": 0,
+						"type": "float"
+					},
+					{
+						"default": 0.1,
+						"label": "Mortar:",
+						"max": 0.5,
+						"min": 0,
+						"name": "mortar",
+						"step": 0,
+						"type": "float"
+					},
+					{
+						"default": 0.1,
+						"label": "Bevel:",
+						"max": 0.5,
+						"min": 0,
+						"name": "bevel",
+						"step": 0,
+						"type": "float"
+					}
+				]
+			},
+			"type": "shader"
+		},
+		{
+			"name": "blend",
+			"node_position": {
+				"x": -286.5,
+				"y": 14.5
+			},
+			"parameters": {
+				"amount": 1,
+				"blend_type": 2
+			},
+			"type": "blend"
+		},
+		{
+			"name": "pattern",
+			"node_position": {
+				"x": -547.5,
+				"y": -227.068176
+			},
+			"parameters": {
+				"mix": 0,
+				"x_scale": 1,
+				"x_wave": 3,
+				"y_scale": 0,
+				"y_wave": 4
+			},
+			"type": "pattern"
+		},
+		{
+			"name": "colorize",
+			"node_position": {
+				"x": -10.209106,
+				"y": -146.068176
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0,
+							"r": 1
+						},
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 1,
+							"r": 0
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "transform",
+			"node_position": {
+				"x": -258.5,
+				"y": -196.5
+			},
+			"parameters": {
+				"repeat": false,
+				"rotate": 360,
+				"scale_x": 1,
+				"scale_y": 1,
+				"translate_x": 0.5,
+				"translate_y": 0.5
+			},
+			"type": "transform"
+		},
+		{
+			"name": "comment",
+			"node_position": {
+				"x": -391.274048,
+				"y": 165.542206
+			},
+			"parameters": {
+				"size": 4
+			},
+			"size": {
+				"x": 280,
+				"y": 85
+			},
+			"text": "This example shows how to use the 3rd and 4th outputs of the bricks node to get the center of each brick.",
+			"type": "comment"
+		},
+		{
+			"name": "normal_map",
+			"node_position": {
+				"x": 14.29071,
+				"y": -40.645294
+			},
+			"parameters": {
+				"amount": 0.3,
+				"param0": 11,
+				"param1": 11,
+				"param2": 1,
+				"size": 4
+			},
+			"type": "normal_map"
+		}
+	],
+	"parameters": {
+
+	},
+	"type": "graph"
+}

--- a/addons/material_maker/examples/bricks.ptex
+++ b/addons/material_maker/examples/bricks.ptex
@@ -1,1 +1,1223 @@
-{"connections":[{"from":"Perlin","from_port":0,"to":"Warp","to_port":1},{"from":"Warp","from_port":0,"to":"colorize_2","to_port":0},{"from":"colorize_2","from_port":0,"to":"blend_0","to_port":2},{"from":"colorize_0","from_port":0,"to":"blend_0","to_port":1},{"from":"blend_0","from_port":0,"to":"Material","to_port":0},{"from":"colorize_2","from_port":0,"to":"colorize_4","to_port":0},{"from":"colorize_4","from_port":0,"to":"Material","to_port":2},{"from":"blend_1","from_port":0,"to":"colorize_1","to_port":0},{"from":"Warp","from_port":0,"to":"blend_2","to_port":0},{"from":"Perlin","from_port":0,"to":"blend_2","to_port":1},{"from":"blend_2","from_port":0,"to":"colorize_3","to_port":0},{"from":"blend_2","from_port":0,"to":"colorize_6","to_port":0},{"from":"Perlin","from_port":0,"to":"blend_1","to_port":0},{"from":"Perlin","from_port":0,"to":"colorize_0","to_port":0},{"from":"uniform_0","from_port":0,"to":"Material","to_port":1},{"from":"colorize_3","from_port":0,"to":"Material","to_port":5},{"from":"uniform_0","from_port":0,"to":"combine_0","to_port":0},{"from":"colorize_4","from_port":0,"to":"combine_0","to_port":1},{"from":"colorize_1","from_port":0,"to":"adjust_hsv_0","to_port":0},{"from":"adjust_hsv_0","from_port":0,"to":"blend_0","to_port":0},{"from":"graph","from_port":0,"to":"Warp","to_port":0},{"from":"graph","from_port":1,"to":"blend_1","to_port":1},{"from":"colorize_6","from_port":0,"to":"Material","to_port":6},{"from":"blend_2","from_port":0,"to":"normal_map","to_port":0},{"from":"normal_map","from_port":0,"to":"Material","to_port":4}],"label":"Graph","name":"61","node_position":{"x":0,"y":0},"nodes":[{"name":"colorize_0","node_position":{"x":560.943665,"y":50},"parameters":{"gradient":{"points":[{"a":1,"b":0,"g":0,"pos":0,"r":0},{"a":1,"b":1,"g":1,"pos":1,"r":1}],"type":"Gradient"}},"type":"colorize"},{"name":"Material","node_position":{"x":1238,"y":183},"parameters":{"albedo_color":{"a":1,"b":1,"g":1,"r":1,"type":"Color"},"ao_light_affect":1,"depth_scale":0,"emission_energy":1,"metallic":1,"normal_scale":1,"resolution":1,"roughness":1,"size":11},"type":"material"},{"name":"blend_2","node_position":{"x":457,"y":319},"parameters":{"amount":0.551223,"blend_type":0},"type":"blend"},{"name":"blend_0","node_position":{"x":836.943726,"y":-71},"parameters":{"amount":1,"blend_type":0},"type":"blend"},{"name":"colorize_2","node_position":{"x":544.943665,"y":159},"parameters":{"gradient":{"points":[{"a":1,"b":0,"g":0,"pos":0,"r":0},{"a":1,"b":1,"g":1,"pos":0.1,"r":1}],"type":"Gradient"}},"type":"colorize"},{"name":"uniform_0","node_position":{"x":764,"y":164},"parameters":{"color":{"a":1,"b":0,"g":0,"r":0,"type":"Color"}},"type":"uniform"},{"name":"combine_0","node_position":{"x":896,"y":86},"parameters":{"color":{"a":1,"b":1,"g":1,"r":1,"type":"Color"},"name":0},"type":"combine"},{"name":"colorize_4","node_position":{"x":711,"y":215},"parameters":{"gradient":{"points":[{"a":1,"b":1,"g":1,"pos":0,"r":1},{"a":1,"b":0.703125,"g":0.703125,"pos":1,"r":0.703125}],"type":"Gradient"}},"type":"colorize"},{"name":"colorize_6","node_position":{"x":716,"y":284},"parameters":{"gradient":{"points":[{"a":1,"b":1,"g":1,"pos":0,"r":1},{"a":1,"b":0,"g":0,"pos":1,"r":0}],"type":"Gradient"}},"type":"colorize"},{"name":"colorize_3","node_position":{"x":711,"y":361},"parameters":{"gradient":{"points":[{"a":1,"b":0.838542,"g":0.838542,"pos":0.145455,"r":0.838542},{"a":1,"b":1,"g":1,"pos":0.536364,"r":1}],"type":"Gradient"}},"type":"colorize"},{"name":"colorize_1","node_position":{"x":406.943665,"y":-80},"parameters":{"gradient":{"points":[{"a":1,"b":0.0016,"g":0.0016,"pos":0,"r":0.307292},{"a":1,"b":0,"g":0.180135,"pos":0.2,"r":0.606771},{"a":1,"b":0,"g":0,"pos":0.345455,"r":0.3125},{"a":1,"b":0,"g":0.19869,"pos":0.545455,"r":0.669271},{"a":1,"b":0.019368,"g":0.060224,"pos":0.745455,"r":0.309896},{"a":1,"b":0,"g":0.180135,"pos":1,"r":0.606771}],"type":"Gradient"}},"type":"colorize"},{"name":"blend_1","node_position":{"x":316,"y":217},"parameters":{"amount":0.5,"blend_type":6},"type":"blend"},{"name":"Perlin","node_position":{"x":32,"y":238},"parameters":{"iterations":6,"persistence":0.85,"scale_x":4,"scale_y":4},"type":"perlin"},{"name":"Warp","node_position":{"x":306,"y":55.75},"parameters":{"amount":0.04,"eps":0.045,"epsilon":0},"type":"warp"},{"name":"adjust_hsv_0","node_position":{"x":590.224792,"y":-74.268188},"parameters":{"hue":0,"saturation":1,"value":1},"type":"adjust_hsv"},{"name":"_2_2","node_position":{"x":244.467804,"y":-350.036743},"parameters":{"param0":0,"param1":0,"param2":0,"param3":0},"type":"remote","widgets":[{"configurations":{"Basket weave":[{"node":"Bricks","value":3,"widget":"pattern"},{"node":"Bricks","value":2,"widget":"repeat"},{"node":"Bricks","value":2,"widget":"rows"},{"node":"Bricks","value":2,"widget":"columns"},{"node":"switch_0","value":0,"widget":"source"},{"node":"voronoi_0","value":8,"widget":"scale_x"},{"node":"voronoi_0","value":8,"widget":"scale_y"}],"Herring bone":[{"node":"Bricks","value":2,"widget":"pattern"},{"node":"Bricks","value":2,"widget":"repeat"},{"node":"Bricks","value":2,"widget":"rows"},{"node":"Bricks","value":2,"widget":"columns"},{"node":"switch_0","value":0,"widget":"source"},{"node":"voronoi_0","value":8,"widget":"scale_x"},{"node":"voronoi_0","value":8,"widget":"scale_y"}],"Running bond 1":[{"node":"Bricks","value":0,"widget":"pattern"},{"node":"Bricks","value":1,"widget":"repeat"},{"node":"Bricks","value":8,"widget":"rows"},{"node":"Bricks","value":4,"widget":"columns"},{"node":"switch_0","value":0,"widget":"source"},{"node":"voronoi_0","value":8,"widget":"scale_x"},{"node":"voronoi_0","value":8,"widget":"scale_y"}],"Running bond 2":[{"node":"Bricks","value":1,"widget":"pattern"},{"node":"Bricks","value":1,"widget":"repeat"},{"node":"Bricks","value":8,"widget":"rows"},{"node":"Bricks","value":4,"widget":"columns"},{"node":"switch_0","value":0,"widget":"source"},{"node":"voronoi_0","value":8,"widget":"scale_x"},{"node":"voronoi_0","value":8,"widget":"scale_y"}],"Spanish bond":[{"node":"Bricks","value":4,"widget":"pattern"},{"node":"Bricks","value":3,"widget":"repeat"},{"node":"Bricks","value":2,"widget":"rows"},{"node":"Bricks","value":2,"widget":"columns"},{"node":"switch_0","value":0,"widget":"source"},{"node":"voronoi_0","value":8,"widget":"scale_x"},{"node":"voronoi_0","value":8,"widget":"scale_y"}],"Uneven":[{"node":"Bricks","value":3,"widget":"pattern"},{"node":"Bricks","value":2,"widget":"repeat"},{"node":"Bricks","value":2,"widget":"rows"},{"node":"Bricks","value":2,"widget":"columns"},{"node":"switch_0","value":1,"widget":"source"},{"node":"voronoi_0","value":8,"widget":"scale_x"},{"node":"voronoi_0","value":8,"widget":"scale_y"}]},"label":"Pattern","linked_widgets":[{"node":"Bricks","widget":"pattern"},{"node":"Bricks","widget":"repeat"},{"node":"Bricks","widget":"rows"},{"node":"Bricks","widget":"columns"},{"node":"switch_0","widget":"source"},{"node":"voronoi_0","widget":"scale_x"},{"node":"voronoi_0","widget":"scale_y"}],"type":"config_control"},{"label":"Hue","linked_widgets":[{"node":"adjust_hsv_0","widget":"hue"}],"type":"linked_control"},{"label":"Saturation","linked_widgets":[{"node":"adjust_hsv_0","widget":"saturation"}],"type":"linked_control"},{"label":"Value","linked_widgets":[{"node":"adjust_hsv_0","widget":"value"}],"type":"linked_control"}]},{"connections":[{"from":"switch_0","from_port":0,"to":"gen_outputs","to_port":0},{"from":"switch_0","from_port":1,"to":"gen_outputs","to_port":1},{"from":"Bricks","from_port":0,"to":"switch_0","to_port":0},{"from":"voronoi_0","from_port":2,"to":"switch_0","to_port":3},{"from":"voronoi_0","from_port":1,"to":"colorize_5","to_port":0},{"from":"colorize_5","from_port":0,"to":"switch_0","to_port":2},{"from":"Bricks","from_port":1,"to":"switch_0","to_port":1}],"label":"Modular Bricks","name":"graph","node_position":{"x":15,"y":56},"nodes":[{"name":"colorize_5","node_position":{"x":-238.515076,"y":-62.762329},"parameters":{"gradient":{"points":[{"a":1,"b":0,"g":0,"pos":0.027273,"r":0},{"a":1,"b":1,"g":1,"pos":0.2,"r":1}],"type":"Gradient"}},"type":"colorize"},{"name":"Bricks","node_position":{"x":-250,"y":-240},"parameters":{"bevel":0.2,"columns":2,"mortar":0.05,"pattern":3,"repeat":2,"row_offset":0.5,"rows":2},"type":"bricks"},{"name":"voronoi_0","node_position":{"x":-248.515076,"y":-2.762329},"parameters":{"intensity":1,"randomness":1,"scale_x":8,"scale_y":8},"type":"voronoi"},{"name":"switch_0","node_position":{"x":-7.515076,"y":-126.762329},"parameters":{"choices":2,"outputs":2,"source":0},"type":"switch"},{"name":"gen_parameters","node_position":{"x":-295.330811,"y":-317.657043},"parameters":{"param0":0,"param1":0,"param2":0,"param3":0},"type":"remote","widgets":[{"configurations":{"Basket weave":[{"node":"Bricks","value":3,"widget":"pattern"},{"node":"Bricks","value":2,"widget":"repeat"},{"node":"Bricks","value":2,"widget":"rows"},{"node":"Bricks","value":2,"widget":"columns"},{"node":"switch_0","value":0,"widget":"source"},{"node":"voronoi_0","value":8,"widget":"scale_x"},{"node":"voronoi_0","value":8,"widget":"scale_y"}],"Herring bone":[{"node":"Bricks","value":2,"widget":"pattern"},{"node":"Bricks","value":2,"widget":"repeat"},{"node":"Bricks","value":2,"widget":"rows"},{"node":"Bricks","value":2,"widget":"columns"},{"node":"switch_0","value":0,"widget":"source"},{"node":"voronoi_0","value":8,"widget":"scale_x"},{"node":"voronoi_0","value":8,"widget":"scale_y"}],"Running bond 1":[{"node":"Bricks","value":0,"widget":"pattern"},{"node":"Bricks","value":1,"widget":"repeat"},{"node":"Bricks","value":8,"widget":"rows"},{"node":"Bricks","value":4,"widget":"columns"},{"node":"switch_0","value":0,"widget":"source"},{"node":"voronoi_0","value":8,"widget":"scale_x"},{"node":"voronoi_0","value":8,"widget":"scale_y"}],"Running bond 2":[{"node":"Bricks","value":1,"widget":"pattern"},{"node":"Bricks","value":1,"widget":"repeat"},{"node":"Bricks","value":8,"widget":"rows"},{"node":"Bricks","value":4,"widget":"columns"},{"node":"switch_0","value":0,"widget":"source"},{"node":"voronoi_0","value":8,"widget":"scale_x"},{"node":"voronoi_0","value":8,"widget":"scale_y"}],"Spanish bond":[{"node":"Bricks","value":4,"widget":"pattern"},{"node":"Bricks","value":3,"widget":"repeat"},{"node":"Bricks","value":2,"widget":"rows"},{"node":"Bricks","value":2,"widget":"columns"},{"node":"switch_0","value":0,"widget":"source"},{"node":"voronoi_0","value":8,"widget":"scale_x"},{"node":"voronoi_0","value":8,"widget":"scale_y"}],"Uneven":[{"node":"Bricks","value":3,"widget":"pattern"},{"node":"Bricks","value":2,"widget":"repeat"},{"node":"Bricks","value":2,"widget":"rows"},{"node":"Bricks","value":2,"widget":"columns"},{"node":"switch_0","value":1,"widget":"source"},{"node":"voronoi_0","value":8,"widget":"scale_x"},{"node":"voronoi_0","value":8,"widget":"scale_y"}]},"label":"Pattern","linked_widgets":[{"node":"Bricks","widget":"pattern"},{"node":"Bricks","widget":"repeat"},{"node":"Bricks","widget":"rows"},{"node":"Bricks","widget":"columns"},{"node":"switch_0","widget":"source"},{"node":"voronoi_0","widget":"scale_x"},{"node":"voronoi_0","widget":"scale_y"}],"type":"config_control"},{"label":"Hue","linked_widgets":[{"node":"adjust_hsv_0","widget":"hue"}],"type":"linked_control"},{"label":"Saturation","linked_widgets":[{"node":"adjust_hsv_0","widget":"saturation"}],"type":"linked_control"},{"label":"Value","linked_widgets":[{"node":"adjust_hsv_0","widget":"value"}],"type":"linked_control"}]},{"name":"gen_outputs","node_position":{"x":190,"y":-124},"parameters":{},"ports":[{"name":"port0","type":"rgba"},{"name":"port1","type":"rgba"}],"type":"ios"}],"parameters":{},"type":"graph"},{"connections":[{"from":"nm_convolution","from_port":0,"to":"nm_postprocess","to_port":0},{"from":"nm_postprocess","from_port":0,"to":"gen_outputs","to_port":0},{"from":"gen_inputs","from_port":0,"to":"buffer","to_port":0},{"from":"buffer","from_port":0,"to":"nm_convolution","to_port":0}],"label":"Normal Map","name":"normal_map","node_position":{"x":960.584229,"y":273.420258},"nodes":[{"name":"buffer","node_position":{"x":-687.663818,"y":125.60614},"parameters":{"size":11},"type":"buffer"},{"convolution_params":{"input_type":"f","matrix":[[[-1,-1,0],[0,-2,0],[1,-1,0]],[[-2,0,0],0,[2,0,0]],[[-1,1,0],[0,2,0],[1,1,0]]],"output_type":"rgb","x":1,"y":1},"name":"nm_convolution","node_position":{"x":-690.25,"y":174.25},"parameters":{"size":11},"type":"convolution"},{"name":"nm_postprocess","node_position":{"x":-690.25,"y":222.25},"parameters":{"amount":0.995,"size":11},"shader_model":{"code":"","global":"","inputs":[{"default":"vec3(0.0)","label":"","name":"in","type":"rgb"}],"instance":"","name":"NormalMapPostProcess","outputs":[{"rgb":"0.5*normalize($in($uv)*$amount*vec3(-1.0, 1.0, 1.0)*$size/128.0-vec3(0.0, 0.0, 1.0))+vec3(0.5)","type":"rgb"}],"parameters":[{"default":9,"first":4,"label":"","last":11,"name":"size","type":"size"},{"default":1,"label":"","max":2,"min":0,"name":"amount","step":0.005,"type":"float"}]},"type":"shader"},{"name":"gen_parameters","node_position":{"x":-718.910156,"y":26.083313},"parameters":{"param0":11,"param1":0.995},"type":"remote","widgets":[{"label":"Size","linked_widgets":[{"node":"buffer","widget":"size"},{"node":"nm_convolution","widget":"size"},{"node":"nm_postprocess","widget":"size"}],"type":"linked_control"},{"label":"Amount","linked_widgets":[{"node":"nm_postprocess","widget":"amount"}],"type":"linked_control"}]},{"name":"gen_outputs","node_position":{"x":-407.663818,"y":151.047363},"parameters":{},"ports":[{"name":"port0","type":"rgba"}],"type":"ios"},{"name":"gen_inputs","node_position":{"x":-870.910156,"y":157.047363},"parameters":{},"ports":[{"name":"port0","type":"rgba"}],"type":"ios"}],"parameters":{"param0":11,"param1":0.995},"type":"graph"}],"parameters":{},"type":"graph"}
+{
+	"connections": [
+		{
+			"from": "Perlin",
+			"from_port": 0,
+			"to": "Warp",
+			"to_port": 1
+		},
+		{
+			"from": "Warp",
+			"from_port": 0,
+			"to": "colorize_2",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_2",
+			"from_port": 0,
+			"to": "blend_0",
+			"to_port": 2
+		},
+		{
+			"from": "colorize_0",
+			"from_port": 0,
+			"to": "blend_0",
+			"to_port": 1
+		},
+		{
+			"from": "blend_0",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_2",
+			"from_port": 0,
+			"to": "colorize_4",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_4",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 2
+		},
+		{
+			"from": "blend_1",
+			"from_port": 0,
+			"to": "colorize_1",
+			"to_port": 0
+		},
+		{
+			"from": "Warp",
+			"from_port": 0,
+			"to": "blend_2",
+			"to_port": 0
+		},
+		{
+			"from": "Perlin",
+			"from_port": 0,
+			"to": "blend_2",
+			"to_port": 1
+		},
+		{
+			"from": "blend_2",
+			"from_port": 0,
+			"to": "colorize_3",
+			"to_port": 0
+		},
+		{
+			"from": "blend_2",
+			"from_port": 0,
+			"to": "colorize_6",
+			"to_port": 0
+		},
+		{
+			"from": "Perlin",
+			"from_port": 0,
+			"to": "blend_1",
+			"to_port": 0
+		},
+		{
+			"from": "Perlin",
+			"from_port": 0,
+			"to": "colorize_0",
+			"to_port": 0
+		},
+		{
+			"from": "uniform_0",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 1
+		},
+		{
+			"from": "colorize_3",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 5
+		},
+		{
+			"from": "uniform_0",
+			"from_port": 0,
+			"to": "combine_0",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_4",
+			"from_port": 0,
+			"to": "combine_0",
+			"to_port": 1
+		},
+		{
+			"from": "colorize_1",
+			"from_port": 0,
+			"to": "adjust_hsv_0",
+			"to_port": 0
+		},
+		{
+			"from": "adjust_hsv_0",
+			"from_port": 0,
+			"to": "blend_0",
+			"to_port": 0
+		},
+		{
+			"from": "graph",
+			"from_port": 0,
+			"to": "Warp",
+			"to_port": 0
+		},
+		{
+			"from": "graph",
+			"from_port": 1,
+			"to": "blend_1",
+			"to_port": 1
+		},
+		{
+			"from": "colorize_6",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 6
+		},
+		{
+			"from": "blend_2",
+			"from_port": 0,
+			"to": "normal_map",
+			"to_port": 0
+		},
+		{
+			"from": "normal_map",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 4
+		}
+	],
+	"label": "Graph",
+	"name": "61",
+	"node_position": {
+		"x": 0,
+		"y": 0
+	},
+	"nodes": [
+		{
+			"name": "colorize_0",
+			"node_position": {
+				"x": 560.943665,
+				"y": 50
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0,
+							"r": 0
+						},
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 1,
+							"r": 1
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "Material",
+			"node_position": {
+				"x": 1238,
+				"y": 183
+			},
+			"parameters": {
+				"albedo_color": {
+					"a": 1,
+					"b": 1,
+					"g": 1,
+					"r": 1,
+					"type": "Color"
+				},
+				"ao_light_affect": 1,
+				"depth_scale": 0,
+				"emission_energy": 1,
+				"metallic": 1,
+				"normal_scale": 1,
+				"resolution": 1,
+				"roughness": 1,
+				"size": 11
+			},
+			"type": "material"
+		},
+		{
+			"name": "blend_2",
+			"node_position": {
+				"x": 457,
+				"y": 319
+			},
+			"parameters": {
+				"amount": 0.551223,
+				"blend_type": 0
+			},
+			"type": "blend"
+		},
+		{
+			"name": "blend_0",
+			"node_position": {
+				"x": 836.943726,
+				"y": -71
+			},
+			"parameters": {
+				"amount": 1,
+				"blend_type": 0
+			},
+			"type": "blend"
+		},
+		{
+			"name": "colorize_2",
+			"node_position": {
+				"x": 544.943665,
+				"y": 159
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0,
+							"r": 0
+						},
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0.1,
+							"r": 1
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "uniform_0",
+			"node_position": {
+				"x": 764,
+				"y": 164
+			},
+			"parameters": {
+				"color": {
+					"a": 1,
+					"b": 0,
+					"g": 0,
+					"r": 0,
+					"type": "Color"
+				}
+			},
+			"type": "uniform"
+		},
+		{
+			"name": "combine_0",
+			"node_position": {
+				"x": 896,
+				"y": 86
+			},
+			"parameters": {
+				"color": {
+					"a": 1,
+					"b": 1,
+					"g": 1,
+					"r": 1,
+					"type": "Color"
+				},
+				"name": 0
+			},
+			"type": "combine"
+		},
+		{
+			"name": "colorize_4",
+			"node_position": {
+				"x": 711,
+				"y": 215
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0,
+							"r": 1
+						},
+						{
+							"a": 1,
+							"b": 0.703125,
+							"g": 0.703125,
+							"pos": 1,
+							"r": 0.703125
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "colorize_6",
+			"node_position": {
+				"x": 716,
+				"y": 284
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0,
+							"r": 1
+						},
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 1,
+							"r": 0
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "colorize_3",
+			"node_position": {
+				"x": 711,
+				"y": 361
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0.838542,
+							"g": 0.838542,
+							"pos": 0.145455,
+							"r": 0.838542
+						},
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0.536364,
+							"r": 1
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "colorize_1",
+			"node_position": {
+				"x": 406.943665,
+				"y": -80
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0.0016,
+							"g": 0.0016,
+							"pos": 0,
+							"r": 0.307292
+						},
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0.180135,
+							"pos": 0.2,
+							"r": 0.606771
+						},
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0.345455,
+							"r": 0.3125
+						},
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0.19869,
+							"pos": 0.545455,
+							"r": 0.669271
+						},
+						{
+							"a": 1,
+							"b": 0.019368,
+							"g": 0.060224,
+							"pos": 0.745455,
+							"r": 0.309896
+						},
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0.180135,
+							"pos": 1,
+							"r": 0.606771
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "blend_1",
+			"node_position": {
+				"x": 316,
+				"y": 217
+			},
+			"parameters": {
+				"amount": 0.5,
+				"blend_type": 6
+			},
+			"type": "blend"
+		},
+		{
+			"name": "Perlin",
+			"node_position": {
+				"x": 32,
+				"y": 238
+			},
+			"parameters": {
+				"iterations": 6,
+				"persistence": 0.85,
+				"scale_x": 4,
+				"scale_y": 4
+			},
+			"type": "perlin"
+		},
+		{
+			"name": "Warp",
+			"node_position": {
+				"x": 306,
+				"y": 55.75
+			},
+			"parameters": {
+				"amount": 0.04,
+				"eps": 0.045,
+				"epsilon": 0
+			},
+			"type": "warp"
+		},
+		{
+			"name": "adjust_hsv_0",
+			"node_position": {
+				"x": 590.224792,
+				"y": -74.268188
+			},
+			"parameters": {
+				"hue": 0,
+				"saturation": 1,
+				"value": 1
+			},
+			"type": "adjust_hsv"
+		},
+		{
+			"name": "_2_2",
+			"node_position": {
+				"x": 244.467804,
+				"y": -350.036743
+			},
+			"parameters": {
+				"param1": 0,
+				"param2": 0,
+				"param3": 0
+			},
+			"type": "remote",
+			"widgets": [
+				{
+					"label": "Hue",
+					"linked_widgets": [
+						{
+							"node": "adjust_hsv_0",
+							"widget": "hue"
+						}
+					],
+					"name": "param1",
+					"type": "linked_control"
+				},
+				{
+					"label": "Saturation",
+					"linked_widgets": [
+						{
+							"node": "adjust_hsv_0",
+							"widget": "saturation"
+						}
+					],
+					"name": "param2",
+					"type": "linked_control"
+				},
+				{
+					"label": "Value",
+					"linked_widgets": [
+						{
+							"node": "adjust_hsv_0",
+							"widget": "value"
+						}
+					],
+					"name": "param3",
+					"type": "linked_control"
+				}
+			]
+		},
+		{
+			"connections": [
+				{
+					"from": "switch_0",
+					"from_port": 0,
+					"to": "gen_outputs",
+					"to_port": 0
+				},
+				{
+					"from": "switch_0",
+					"from_port": 1,
+					"to": "gen_outputs",
+					"to_port": 1
+				},
+				{
+					"from": "Bricks",
+					"from_port": 0,
+					"to": "switch_0",
+					"to_port": 0
+				},
+				{
+					"from": "voronoi_0",
+					"from_port": 2,
+					"to": "switch_0",
+					"to_port": 3
+				},
+				{
+					"from": "voronoi_0",
+					"from_port": 1,
+					"to": "colorize_5",
+					"to_port": 0
+				},
+				{
+					"from": "colorize_5",
+					"from_port": 0,
+					"to": "switch_0",
+					"to_port": 2
+				},
+				{
+					"from": "Bricks",
+					"from_port": 1,
+					"to": "switch_0",
+					"to_port": 1
+				}
+			],
+			"label": "Modular Bricks",
+			"name": "graph",
+			"node_position": {
+				"x": 15,
+				"y": 56
+			},
+			"nodes": [
+				{
+					"name": "colorize_5",
+					"node_position": {
+						"x": -238.515076,
+						"y": -62.762329
+					},
+					"parameters": {
+						"gradient": {
+							"points": [
+								{
+									"a": 1,
+									"b": 0,
+									"g": 0,
+									"pos": 0.027273,
+									"r": 0
+								},
+								{
+									"a": 1,
+									"b": 1,
+									"g": 1,
+									"pos": 0.2,
+									"r": 1
+								}
+							],
+							"type": "Gradient"
+						}
+					},
+					"type": "colorize"
+				},
+				{
+					"name": "Bricks",
+					"node_position": {
+						"x": -250,
+						"y": -240
+					},
+					"parameters": {
+						"bevel": 0.2,
+						"columns": 2,
+						"mortar": 0.05,
+						"pattern": 3,
+						"repeat": 2,
+						"row_offset": 0.5,
+						"rows": 2
+					},
+					"type": "bricks"
+				},
+				{
+					"name": "voronoi_0",
+					"node_position": {
+						"x": -248.515076,
+						"y": -2.762329
+					},
+					"parameters": {
+						"intensity": 1,
+						"randomness": 1,
+						"scale_x": 8,
+						"scale_y": 8
+					},
+					"type": "voronoi"
+				},
+				{
+					"name": "switch_0",
+					"node_position": {
+						"x": -7.515076,
+						"y": -126.762329
+					},
+					"parameters": {
+						"choices": 2,
+						"outputs": 2,
+						"source": 0
+					},
+					"type": "switch"
+				},
+				{
+					"name": "gen_parameters",
+					"node_position": {
+						"x": -295.330811,
+						"y": -317.657043
+					},
+					"parameters": {
+						"param0": 0
+					},
+					"type": "remote",
+					"widgets": [
+						{
+							"configurations": {
+								"Basket weave": [
+									{
+										"node": "Bricks",
+										"value": 3,
+										"widget": "pattern"
+									},
+									{
+										"node": "Bricks",
+										"value": 2,
+										"widget": "repeat"
+									},
+									{
+										"node": "Bricks",
+										"value": 2,
+										"widget": "rows"
+									},
+									{
+										"node": "Bricks",
+										"value": 2,
+										"widget": "columns"
+									},
+									{
+										"node": "switch_0",
+										"value": 0,
+										"widget": "source"
+									},
+									{
+										"node": "voronoi_0",
+										"value": 8,
+										"widget": "scale_x"
+									},
+									{
+										"node": "voronoi_0",
+										"value": 8,
+										"widget": "scale_y"
+									}
+								],
+								"Herring bone": [
+									{
+										"node": "Bricks",
+										"value": 2,
+										"widget": "pattern"
+									},
+									{
+										"node": "Bricks",
+										"value": 2,
+										"widget": "repeat"
+									},
+									{
+										"node": "Bricks",
+										"value": 2,
+										"widget": "rows"
+									},
+									{
+										"node": "Bricks",
+										"value": 2,
+										"widget": "columns"
+									},
+									{
+										"node": "switch_0",
+										"value": 0,
+										"widget": "source"
+									},
+									{
+										"node": "voronoi_0",
+										"value": 8,
+										"widget": "scale_x"
+									},
+									{
+										"node": "voronoi_0",
+										"value": 8,
+										"widget": "scale_y"
+									}
+								],
+								"Running bond 1": [
+									{
+										"node": "Bricks",
+										"value": 0,
+										"widget": "pattern"
+									},
+									{
+										"node": "Bricks",
+										"value": 1,
+										"widget": "repeat"
+									},
+									{
+										"node": "Bricks",
+										"value": 8,
+										"widget": "rows"
+									},
+									{
+										"node": "Bricks",
+										"value": 4,
+										"widget": "columns"
+									},
+									{
+										"node": "switch_0",
+										"value": 0,
+										"widget": "source"
+									},
+									{
+										"node": "voronoi_0",
+										"value": 8,
+										"widget": "scale_x"
+									},
+									{
+										"node": "voronoi_0",
+										"value": 8,
+										"widget": "scale_y"
+									}
+								],
+								"Running bond 2": [
+									{
+										"node": "Bricks",
+										"value": 1,
+										"widget": "pattern"
+									},
+									{
+										"node": "Bricks",
+										"value": 1,
+										"widget": "repeat"
+									},
+									{
+										"node": "Bricks",
+										"value": 8,
+										"widget": "rows"
+									},
+									{
+										"node": "Bricks",
+										"value": 4,
+										"widget": "columns"
+									},
+									{
+										"node": "switch_0",
+										"value": 0,
+										"widget": "source"
+									},
+									{
+										"node": "voronoi_0",
+										"value": 8,
+										"widget": "scale_x"
+									},
+									{
+										"node": "voronoi_0",
+										"value": 8,
+										"widget": "scale_y"
+									}
+								],
+								"Spanish bond": [
+									{
+										"node": "Bricks",
+										"value": 4,
+										"widget": "pattern"
+									},
+									{
+										"node": "Bricks",
+										"value": 3,
+										"widget": "repeat"
+									},
+									{
+										"node": "Bricks",
+										"value": 2,
+										"widget": "rows"
+									},
+									{
+										"node": "Bricks",
+										"value": 2,
+										"widget": "columns"
+									},
+									{
+										"node": "switch_0",
+										"value": 0,
+										"widget": "source"
+									},
+									{
+										"node": "voronoi_0",
+										"value": 8,
+										"widget": "scale_x"
+									},
+									{
+										"node": "voronoi_0",
+										"value": 8,
+										"widget": "scale_y"
+									}
+								],
+								"Uneven": [
+									{
+										"node": "Bricks",
+										"value": 3,
+										"widget": "pattern"
+									},
+									{
+										"node": "Bricks",
+										"value": 2,
+										"widget": "repeat"
+									},
+									{
+										"node": "Bricks",
+										"value": 2,
+										"widget": "rows"
+									},
+									{
+										"node": "Bricks",
+										"value": 2,
+										"widget": "columns"
+									},
+									{
+										"node": "switch_0",
+										"value": 1,
+										"widget": "source"
+									},
+									{
+										"node": "voronoi_0",
+										"value": 8,
+										"widget": "scale_x"
+									},
+									{
+										"node": "voronoi_0",
+										"value": 8,
+										"widget": "scale_y"
+									}
+								]
+							},
+							"label": "Pattern",
+							"linked_widgets": [
+								{
+									"node": "Bricks",
+									"widget": "pattern"
+								},
+								{
+									"node": "Bricks",
+									"widget": "repeat"
+								},
+								{
+									"node": "Bricks",
+									"widget": "rows"
+								},
+								{
+									"node": "Bricks",
+									"widget": "columns"
+								},
+								{
+									"node": "switch_0",
+									"widget": "source"
+								},
+								{
+									"node": "voronoi_0",
+									"widget": "scale_x"
+								},
+								{
+									"node": "voronoi_0",
+									"widget": "scale_y"
+								}
+							],
+							"name": "param0",
+							"type": "config_control"
+						}
+					]
+				},
+				{
+					"name": "gen_outputs",
+					"node_position": {
+						"x": 190,
+						"y": -124
+					},
+					"parameters": {
+
+					},
+					"ports": [
+						{
+							"name": "port0",
+							"type": "rgba"
+						},
+						{
+							"name": "port1",
+							"type": "rgba"
+						}
+					],
+					"type": "ios"
+				}
+			],
+			"parameters": {
+
+			},
+			"type": "graph"
+		},
+		{
+			"connections": [
+				{
+					"from": "nm_convolution",
+					"from_port": 0,
+					"to": "nm_postprocess",
+					"to_port": 0
+				},
+				{
+					"from": "nm_postprocess",
+					"from_port": 0,
+					"to": "gen_outputs",
+					"to_port": 0
+				},
+				{
+					"from": "gen_inputs",
+					"from_port": 0,
+					"to": "buffer",
+					"to_port": 0
+				},
+				{
+					"from": "buffer",
+					"from_port": 0,
+					"to": "nm_convolution",
+					"to_port": 0
+				}
+			],
+			"label": "Normal Map",
+			"name": "normal_map",
+			"node_position": {
+				"x": 960.584229,
+				"y": 273.420258
+			},
+			"nodes": [
+				{
+					"name": "buffer",
+					"node_position": {
+						"x": -687.663818,
+						"y": 125.60614
+					},
+					"parameters": {
+						"size": 11
+					},
+					"type": "buffer"
+				},
+				{
+					"convolution_params": {
+						"input_type": "f",
+						"matrix": [
+							[
+								[
+									-1,
+									-1,
+									0
+								],
+								[
+									0,
+									-2,
+									0
+								],
+								[
+									1,
+									-1,
+									0
+								]
+							],
+							[
+								[
+									-2,
+									0,
+									0
+								],
+								0,
+								[
+									2,
+									0,
+									0
+								]
+							],
+							[
+								[
+									-1,
+									1,
+									0
+								],
+								[
+									0,
+									2,
+									0
+								],
+								[
+									1,
+									1,
+									0
+								]
+							]
+						],
+						"output_type": "rgb",
+						"x": 1,
+						"y": 1
+					},
+					"name": "nm_convolution",
+					"node_position": {
+						"x": -690.25,
+						"y": 174.25
+					},
+					"parameters": {
+						"size": 11
+					},
+					"type": "convolution"
+				},
+				{
+					"name": "nm_postprocess",
+					"node_position": {
+						"x": -690.25,
+						"y": 222.25
+					},
+					"parameters": {
+						"amount": 0.995,
+						"size": 11
+					},
+					"shader_model": {
+						"code": "",
+						"global": "",
+						"inputs": [
+							{
+								"default": "vec3(0.0)",
+								"label": "",
+								"name": "in",
+								"type": "rgb"
+							}
+						],
+						"instance": "",
+						"name": "NormalMapPostProcess",
+						"outputs": [
+							{
+								"rgb": "0.5*normalize($in($uv)*$amount*vec3(-1.0, 1.0, 1.0)*$size/128.0-vec3(0.0, 0.0, 1.0))+vec3(0.5)",
+								"type": "rgb"
+							}
+						],
+						"parameters": [
+							{
+								"default": 9,
+								"first": 4,
+								"label": "",
+								"last": 11,
+								"name": "size",
+								"type": "size"
+							},
+							{
+								"default": 1,
+								"label": "",
+								"max": 2,
+								"min": 0,
+								"name": "amount",
+								"step": 0.005,
+								"type": "float"
+							}
+						]
+					},
+					"type": "shader"
+				},
+				{
+					"name": "gen_parameters",
+					"node_position": {
+						"x": -718.910156,
+						"y": 26.083313
+					},
+					"parameters": {
+						"param0": 11,
+						"param1": 0.995
+					},
+					"type": "remote",
+					"widgets": [
+						{
+							"label": "Size",
+							"linked_widgets": [
+								{
+									"node": "buffer",
+									"widget": "size"
+								},
+								{
+									"node": "nm_convolution",
+									"widget": "size"
+								},
+								{
+									"node": "nm_postprocess",
+									"widget": "size"
+								}
+							],
+							"name": "param0",
+							"type": "linked_control"
+						},
+						{
+							"label": "Amount",
+							"linked_widgets": [
+								{
+									"node": "nm_postprocess",
+									"widget": "amount"
+								}
+							],
+							"name": "param1",
+							"type": "linked_control"
+						}
+					]
+				},
+				{
+					"name": "gen_outputs",
+					"node_position": {
+						"x": -407.663818,
+						"y": 151.047363
+					},
+					"parameters": {
+
+					},
+					"ports": [
+						{
+							"name": "port0",
+							"type": "rgba"
+						}
+					],
+					"type": "ios"
+				},
+				{
+					"name": "gen_inputs",
+					"node_position": {
+						"x": -870.910156,
+						"y": 157.047363
+					},
+					"parameters": {
+
+					},
+					"ports": [
+						{
+							"name": "port0",
+							"type": "rgba"
+						}
+					],
+					"type": "ios"
+				}
+			],
+			"parameters": {
+				"param0": 11,
+				"param1": 0.995
+			},
+			"type": "graph"
+		}
+	],
+	"parameters": {
+
+	},
+	"type": "graph"
+}

--- a/addons/material_maker/examples/clump_of_grass.ptex
+++ b/addons/material_maker/examples/clump_of_grass.ptex
@@ -1,1 +1,261 @@
-{"connections":[{"from":"colorize_0","from_port":0,"to":"Material","to_port":0},{"from":"perlin_0","from_port":0,"to":"blend_0","to_port":1},{"from":"pattern_0","from_port":0,"to":"blend_0","to_port":0},{"from":"blend_0","from_port":0,"to":"transform_0","to_port":0},{"from":"transform_0","from_port":0,"to":"colorize_0","to_port":0},{"from":"colorize_1","from_port":0,"to":"transform_0","to_port":4},{"from":"pattern_1","from_port":0,"to":"colorize_1","to_port":0},{"from":"transform_0","from_port":0,"to":"normal_map","to_port":0},{"from":"normal_map","from_port":0,"to":"Material","to_port":4}],"label":"Graph","name":"222","node_position":{"x":0,"y":0},"nodes":[{"name":"perlin_0","node_position":{"x":-254,"y":101},"parameters":{"iterations":4,"persistence":1,"scale_x":32,"scale_y":4},"type":"perlin"},{"name":"pattern_0","node_position":{"x":-272,"y":-14},"parameters":{"mix":0,"x_scale":1,"x_wave":0,"y_scale":1,"y_wave":3},"type":"pattern"},{"name":"blend_0","node_position":{"x":-4,"y":18},"parameters":{"amount":1,"blend_type":2},"type":"blend"},{"name":"pattern_1","node_position":{"x":-295,"y":245},"parameters":{"mix":0,"x_scale":4,"x_wave":4,"y_scale":1,"y_wave":3},"type":"pattern"},{"name":"colorize_1","node_position":{"x":-8,"y":207},"parameters":{"gradient":{"points":[{"a":1,"b":1,"g":1,"pos":0,"r":1},{"a":1,"b":0.765625,"g":0.765625,"pos":1,"r":0.765625}],"type":"Gradient"}},"type":"colorize"},{"name":"transform_0","node_position":{"x":206,"y":16},"parameters":{"repeat":false,"rotate":0,"scale_x":1.6,"scale_y":1,"translate_x":0,"translate_y":0},"type":"transform"},{"name":"colorize_0","node_position":{"x":435,"y":12},"parameters":{"gradient":{"points":[{"a":0,"b":0,"g":0.5,"pos":0.081818,"r":0.125},{"a":1,"b":0,"g":0.5,"pos":0.145455,"r":0.125},{"a":1,"b":0,"g":0.203125,"pos":0.436364,"r":0.050781},{"a":1,"b":0,"g":0.362165,"pos":0.727273,"r":0.090541},{"a":1,"b":0,"g":0.203125,"pos":1,"r":0.050781}],"type":"Gradient"}},"type":"colorize"},{"name":"Material","node_position":{"x":790,"y":-6},"parameters":{"albedo_color":{"a":1,"b":1,"g":1,"r":1,"type":"Color"},"ao_light_affect":1,"depth_scale":1,"emission_energy":1,"metallic":0,"normal_scale":1,"resolution":1,"roughness":1,"size":11},"type":"material"},{"name":"normal_map","node_position":{"x":478.850098,"y":143.444443},"parameters":{"amount":0.5,"param0":10,"param1":0.995},"type":"normal_map"}],"parameters":{},"type":"graph"}
+{
+	"connections": [
+		{
+			"from": "colorize_0",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 0
+		},
+		{
+			"from": "perlin_0",
+			"from_port": 0,
+			"to": "blend_0",
+			"to_port": 1
+		},
+		{
+			"from": "pattern_0",
+			"from_port": 0,
+			"to": "blend_0",
+			"to_port": 0
+		},
+		{
+			"from": "blend_0",
+			"from_port": 0,
+			"to": "transform_0",
+			"to_port": 0
+		},
+		{
+			"from": "transform_0",
+			"from_port": 0,
+			"to": "colorize_0",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_1",
+			"from_port": 0,
+			"to": "transform_0",
+			"to_port": 4
+		},
+		{
+			"from": "pattern_1",
+			"from_port": 0,
+			"to": "colorize_1",
+			"to_port": 0
+		},
+		{
+			"from": "transform_0",
+			"from_port": 0,
+			"to": "normal_map",
+			"to_port": 0
+		},
+		{
+			"from": "normal_map",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 4
+		}
+	],
+	"label": "Graph",
+	"name": "222",
+	"node_position": {
+		"x": 0,
+		"y": 0
+	},
+	"nodes": [
+		{
+			"name": "perlin_0",
+			"node_position": {
+				"x": -254,
+				"y": 101
+			},
+			"parameters": {
+				"iterations": 4,
+				"persistence": 1,
+				"scale_x": 32,
+				"scale_y": 4
+			},
+			"type": "perlin"
+		},
+		{
+			"name": "pattern_0",
+			"node_position": {
+				"x": -272,
+				"y": -14
+			},
+			"parameters": {
+				"mix": 0,
+				"x_scale": 1,
+				"x_wave": 0,
+				"y_scale": 1,
+				"y_wave": 3
+			},
+			"type": "pattern"
+		},
+		{
+			"name": "blend_0",
+			"node_position": {
+				"x": -4,
+				"y": 18
+			},
+			"parameters": {
+				"amount": 1,
+				"blend_type": 2
+			},
+			"type": "blend"
+		},
+		{
+			"name": "pattern_1",
+			"node_position": {
+				"x": -295,
+				"y": 245
+			},
+			"parameters": {
+				"mix": 0,
+				"x_scale": 4,
+				"x_wave": 4,
+				"y_scale": 1,
+				"y_wave": 3
+			},
+			"type": "pattern"
+		},
+		{
+			"name": "colorize_1",
+			"node_position": {
+				"x": -8,
+				"y": 207
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0,
+							"r": 1
+						},
+						{
+							"a": 1,
+							"b": 0.765625,
+							"g": 0.765625,
+							"pos": 1,
+							"r": 0.765625
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "transform_0",
+			"node_position": {
+				"x": 206,
+				"y": 16
+			},
+			"parameters": {
+				"repeat": false,
+				"rotate": 0,
+				"scale_x": 1.6,
+				"scale_y": 1,
+				"translate_x": 0,
+				"translate_y": 0
+			},
+			"type": "transform"
+		},
+		{
+			"name": "colorize_0",
+			"node_position": {
+				"x": 435,
+				"y": 12
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 0,
+							"b": 0,
+							"g": 0.5,
+							"pos": 0.081818,
+							"r": 0.125
+						},
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0.5,
+							"pos": 0.145455,
+							"r": 0.125
+						},
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0.203125,
+							"pos": 0.436364,
+							"r": 0.050781
+						},
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0.362165,
+							"pos": 0.727273,
+							"r": 0.090541
+						},
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0.203125,
+							"pos": 1,
+							"r": 0.050781
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "Material",
+			"node_position": {
+				"x": 790,
+				"y": -6
+			},
+			"parameters": {
+				"albedo_color": {
+					"a": 1,
+					"b": 1,
+					"g": 1,
+					"r": 1,
+					"type": "Color"
+				},
+				"ao_light_affect": 1,
+				"depth_scale": 1,
+				"emission_energy": 1,
+				"metallic": 0,
+				"normal_scale": 1,
+				"resolution": 1,
+				"roughness": 1,
+				"size": 11
+			},
+			"type": "material"
+		},
+		{
+			"name": "normal_map",
+			"node_position": {
+				"x": 478.850098,
+				"y": 143.444443
+			},
+			"parameters": {
+				"amount": 0.5,
+				"param0": 10,
+				"param1": 11,
+				"param2": 1,
+				"size": 4
+			},
+			"type": "normal_map"
+		}
+	],
+	"parameters": {
+
+	},
+	"type": "graph"
+}

--- a/addons/material_maker/examples/crocodile_skin.ptex
+++ b/addons/material_maker/examples/crocodile_skin.ptex
@@ -1,1 +1,229 @@
-{"connections":[{"from":"voronoi_0","from_port":0,"to":"colorize_0","to_port":0},{"from":"colorize_0","from_port":0,"to":"normal_map_0","to_port":0},{"from":"normal_map_0","from_port":0,"to":"Material","to_port":4},{"from":"voronoi_0","from_port":0,"to":"colorize_1","to_port":0},{"from":"colorize_1","from_port":0,"to":"Material","to_port":0},{"from":"voronoi_0","from_port":0,"to":"colorize_3","to_port":0},{"from":"colorize_3","from_port":0,"to":"Material","to_port":2},{"from":"uniform_0","from_port":0,"to":"Material","to_port":1}],"label":"Graph","name":"240","node_position":{"x":0,"y":0},"nodes":[{"name":"Material","node_position":{"x":674,"y":164},"parameters":{"albedo_color":{"a":1,"b":1,"g":1,"r":1,"type":"Color"},"ao_light_affect":1,"depth_scale":1,"emission_energy":1,"metallic":1,"normal_scale":1,"resolution":1,"roughness":1,"size":11},"type":"material"},{"name":"colorize_1","node_position":{"x":384,"y":137},"parameters":{"gradient":{"points":[{"a":1,"b":0.010715,"g":0.411458,"pos":0,"r":0.22361},{"a":1,"b":0,"g":1,"pos":1,"r":0.9375}],"type":"Gradient"}},"type":"colorize"},{"name":"colorize_3","node_position":{"x":384,"y":258},"parameters":{"gradient":{"points":[{"a":1,"b":0.505208,"g":0.505208,"pos":0,"r":0.505208},{"a":1,"b":0.78125,"g":0.78125,"pos":1,"r":0.78125}],"type":"Gradient"}},"type":"colorize"},{"name":"uniform_0","node_position":{"x":413,"y":208},"parameters":{"color":{"a":1,"b":0,"g":0,"r":0,"type":"Color"}},"type":"uniform"},{"name":"voronoi_0","node_position":{"x":71,"y":216},"parameters":{"intensity":0.4,"randomness":1,"scale_x":16,"scale_y":16},"type":"voronoi"},{"name":"colorize_0","node_position":{"x":264,"y":331},"parameters":{"gradient":{"points":[{"a":1,"b":0,"g":0,"pos":0,"r":0},{"a":1,"b":0.5,"g":0.5,"pos":0.345455,"r":0.5},{"a":1,"b":1,"g":1,"pos":0.618182,"r":1}],"type":"Gradient"}},"type":"colorize"},{"name":"normal_map_0","node_position":{"x":479,"y":334},"parameters":{"amount":0.5,"param0":11,"param1":0.99,"size":2},"type":"normal_map"}],"parameters":{},"type":"graph"}
+{
+	"connections": [
+		{
+			"from": "voronoi_0",
+			"from_port": 0,
+			"to": "colorize_0",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_0",
+			"from_port": 0,
+			"to": "normal_map_0",
+			"to_port": 0
+		},
+		{
+			"from": "normal_map_0",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 4
+		},
+		{
+			"from": "voronoi_0",
+			"from_port": 0,
+			"to": "colorize_1",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_1",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 0
+		},
+		{
+			"from": "voronoi_0",
+			"from_port": 0,
+			"to": "colorize_3",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_3",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 2
+		},
+		{
+			"from": "uniform_0",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 1
+		}
+	],
+	"label": "Graph",
+	"name": "240",
+	"node_position": {
+		"x": 0,
+		"y": 0
+	},
+	"nodes": [
+		{
+			"name": "Material",
+			"node_position": {
+				"x": 674,
+				"y": 164
+			},
+			"parameters": {
+				"albedo_color": {
+					"a": 1,
+					"b": 1,
+					"g": 1,
+					"r": 1,
+					"type": "Color"
+				},
+				"ao_light_affect": 1,
+				"depth_scale": 1,
+				"emission_energy": 1,
+				"metallic": 1,
+				"normal_scale": 1,
+				"resolution": 1,
+				"roughness": 1,
+				"size": 11
+			},
+			"type": "material"
+		},
+		{
+			"name": "colorize_1",
+			"node_position": {
+				"x": 384,
+				"y": 137
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0.010715,
+							"g": 0.411458,
+							"pos": 0,
+							"r": 0.22361
+						},
+						{
+							"a": 1,
+							"b": 0,
+							"g": 1,
+							"pos": 1,
+							"r": 0.9375
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "colorize_3",
+			"node_position": {
+				"x": 384,
+				"y": 258
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0.505208,
+							"g": 0.505208,
+							"pos": 0,
+							"r": 0.505208
+						},
+						{
+							"a": 1,
+							"b": 0.78125,
+							"g": 0.78125,
+							"pos": 1,
+							"r": 0.78125
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "uniform_0",
+			"node_position": {
+				"x": 413,
+				"y": 208
+			},
+			"parameters": {
+				"color": {
+					"a": 1,
+					"b": 0,
+					"g": 0,
+					"r": 0,
+					"type": "Color"
+				}
+			},
+			"type": "uniform"
+		},
+		{
+			"name": "voronoi_0",
+			"node_position": {
+				"x": 71,
+				"y": 216
+			},
+			"parameters": {
+				"intensity": 0.4,
+				"randomness": 1,
+				"scale_x": 16,
+				"scale_y": 16
+			},
+			"type": "voronoi"
+		},
+		{
+			"name": "colorize_0",
+			"node_position": {
+				"x": 264,
+				"y": 331
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0,
+							"r": 0
+						},
+						{
+							"a": 1,
+							"b": 0.5,
+							"g": 0.5,
+							"pos": 0.345455,
+							"r": 0.5
+						},
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0.618182,
+							"r": 1
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "normal_map_0",
+			"node_position": {
+				"x": 479,
+				"y": 334
+			},
+			"parameters": {
+				"amount": 0.5,
+				"param0": 11,
+				"param1": 11,
+				"param2": 1,
+				"size": 2
+			},
+			"type": "normal_map"
+		}
+	],
+	"parameters": {
+
+	},
+	"type": "graph"
+}

--- a/addons/material_maker/examples/dry_earth.ptex
+++ b/addons/material_maker/examples/dry_earth.ptex
@@ -1,1 +1,376 @@
-{"connections":[{"from":"perlin_0","from_port":0,"to":"colorize_0","to_port":0},{"from":"voronoi_0","from_port":1,"to":"colorize_1","to_port":0},{"from":"colorize_0","from_port":0,"to":"blend_0","to_port":1},{"from":"blend_0","from_port":0,"to":"Material","to_port":0},{"from":"colorize_1","from_port":0,"to":"warp_0","to_port":0},{"from":"perlin_1","from_port":0,"to":"warp_0","to_port":1},{"from":"warp_0","from_port":0,"to":"blend_0","to_port":0},{"from":"colorize_3","from_port":0,"to":"Material","to_port":1},{"from":"perlin_1","from_port":0,"to":"colorize_3","to_port":0},{"from":"warp_0","from_port":0,"to":"colorize_4","to_port":0},{"from":"normal_map_0","from_port":0,"to":"Material","to_port":4},{"from":"colorize_4","from_port":0,"to":"blend_1","to_port":1},{"from":"perlin_0","from_port":0,"to":"blend_1","to_port":0},{"from":"blend_1","from_port":0,"to":"colorize","to_port":0},{"from":"colorize","from_port":0,"to":"normal_map_0","to_port":0},{"from":"blend_1","from_port":0,"to":"Material","to_port":6}],"label":"Graph","name":"258","node_position":{"x":0,"y":0},"nodes":[{"name":"voronoi_0","node_position":{"x":-165,"y":-96.75},"parameters":{"intensity":0.6,"randomness":1,"scale_x":4,"scale_y":4},"type":"voronoi"},{"name":"colorize_1","node_position":{"x":93,"y":-117.75},"parameters":{"gradient":{"points":[{"a":1,"b":0,"g":0,"pos":0,"r":0},{"a":1,"b":1,"g":1,"pos":0.063636,"r":1}],"type":"Gradient"}},"type":"colorize"},{"name":"perlin_1","node_position":{"x":-144,"y":50.25},"parameters":{"iterations":3,"persistence":0.5,"scale_x":4,"scale_y":4},"type":"perlin"},{"name":"colorize_0","node_position":{"x":338,"y":-237.75},"parameters":{"gradient":{"points":[{"a":1,"b":0.200277,"g":0.378784,"pos":0.245455,"r":0.557292},{"a":1,"b":0.03776,"g":0.150513,"pos":0.645455,"r":0.25}],"type":"Gradient"}},"type":"colorize"},{"name":"perlin_0","node_position":{"x":56,"y":-361.75},"parameters":{"iterations":10,"persistence":0.9,"scale_x":2,"scale_y":2},"type":"perlin"},{"name":"Material","node_position":{"x":944,"y":-30},"parameters":{"albedo_color":{"a":1,"b":1,"g":1,"r":1,"type":"Color"},"ao_light_affect":1,"depth_scale":0.1,"emission_energy":1,"metallic":1,"normal_scale":1,"resolution":1,"roughness":1,"size":11},"type":"material"},{"name":"colorize_3","node_position":{"x":465,"y":33.25},"parameters":{"gradient":{"points":[{"a":1,"b":0,"g":0,"pos":0,"r":0},{"a":1,"b":0.520833,"g":0.520833,"pos":1,"r":0.520833}],"type":"Gradient"}},"type":"colorize"},{"name":"blend_0","node_position":{"x":541,"y":-82.75},"parameters":{"amount":0.4,"blend_type":2},"type":"blend"},{"name":"warp_0","node_position":{"x":264,"y":-13.75},"parameters":{"amount":0.4,"eps":0.045,"epsilon":0},"type":"warp"},{"name":"blend_1","node_position":{"x":442,"y":175.25},"parameters":{"amount":0.5,"blend_type":0},"type":"blend"},{"name":"normal_map_0","node_position":{"x":706,"y":95.25},"parameters":{"amount":0.35,"param0":11,"param1":0.99,"size":2},"type":"normal_map"},{"name":"colorize_4","node_position":{"x":252,"y":178.25},"parameters":{"gradient":{"points":[{"a":1,"b":1,"g":1,"pos":0,"r":1},{"a":1,"b":0,"g":0,"pos":1,"r":0}],"type":"Gradient"}},"type":"colorize"},{"name":"colorize","node_position":{"x":717.815796,"y":200.5625},"parameters":{"gradient":{"points":[{"a":1,"b":1,"g":1,"pos":0,"r":1},{"a":1,"b":0,"g":0,"pos":1,"r":0}],"type":"Gradient"}},"type":"colorize"}],"parameters":{},"type":"graph"}
+{
+	"connections": [
+		{
+			"from": "perlin_0",
+			"from_port": 0,
+			"to": "colorize_0",
+			"to_port": 0
+		},
+		{
+			"from": "voronoi_0",
+			"from_port": 1,
+			"to": "colorize_1",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_0",
+			"from_port": 0,
+			"to": "blend_0",
+			"to_port": 1
+		},
+		{
+			"from": "blend_0",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_1",
+			"from_port": 0,
+			"to": "warp_0",
+			"to_port": 0
+		},
+		{
+			"from": "perlin_1",
+			"from_port": 0,
+			"to": "warp_0",
+			"to_port": 1
+		},
+		{
+			"from": "warp_0",
+			"from_port": 0,
+			"to": "blend_0",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_3",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 1
+		},
+		{
+			"from": "perlin_1",
+			"from_port": 0,
+			"to": "colorize_3",
+			"to_port": 0
+		},
+		{
+			"from": "warp_0",
+			"from_port": 0,
+			"to": "colorize_4",
+			"to_port": 0
+		},
+		{
+			"from": "normal_map_0",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 4
+		},
+		{
+			"from": "colorize_4",
+			"from_port": 0,
+			"to": "blend_1",
+			"to_port": 1
+		},
+		{
+			"from": "perlin_0",
+			"from_port": 0,
+			"to": "blend_1",
+			"to_port": 0
+		},
+		{
+			"from": "blend_1",
+			"from_port": 0,
+			"to": "colorize",
+			"to_port": 0
+		},
+		{
+			"from": "colorize",
+			"from_port": 0,
+			"to": "normal_map_0",
+			"to_port": 0
+		},
+		{
+			"from": "blend_1",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 6
+		}
+	],
+	"label": "Graph",
+	"name": "258",
+	"node_position": {
+		"x": 0,
+		"y": 0
+	},
+	"nodes": [
+		{
+			"name": "voronoi_0",
+			"node_position": {
+				"x": -165,
+				"y": -96.75
+			},
+			"parameters": {
+				"intensity": 0.6,
+				"randomness": 1,
+				"scale_x": 4,
+				"scale_y": 4
+			},
+			"type": "voronoi"
+		},
+		{
+			"name": "colorize_1",
+			"node_position": {
+				"x": 93,
+				"y": -117.75
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0,
+							"r": 0
+						},
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0.063636,
+							"r": 1
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "perlin_1",
+			"node_position": {
+				"x": -144,
+				"y": 50.25
+			},
+			"parameters": {
+				"iterations": 3,
+				"persistence": 0.5,
+				"scale_x": 4,
+				"scale_y": 4
+			},
+			"type": "perlin"
+		},
+		{
+			"name": "colorize_0",
+			"node_position": {
+				"x": 338,
+				"y": -237.75
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0.200277,
+							"g": 0.378784,
+							"pos": 0.245455,
+							"r": 0.557292
+						},
+						{
+							"a": 1,
+							"b": 0.03776,
+							"g": 0.150513,
+							"pos": 0.645455,
+							"r": 0.25
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "perlin_0",
+			"node_position": {
+				"x": 56,
+				"y": -361.75
+			},
+			"parameters": {
+				"iterations": 10,
+				"persistence": 0.9,
+				"scale_x": 2,
+				"scale_y": 2
+			},
+			"type": "perlin"
+		},
+		{
+			"name": "Material",
+			"node_position": {
+				"x": 944,
+				"y": -30
+			},
+			"parameters": {
+				"albedo_color": {
+					"a": 1,
+					"b": 1,
+					"g": 1,
+					"r": 1,
+					"type": "Color"
+				},
+				"ao_light_affect": 1,
+				"depth_scale": 0.1,
+				"emission_energy": 1,
+				"metallic": 1,
+				"normal_scale": 1,
+				"resolution": 1,
+				"roughness": 1,
+				"size": 11
+			},
+			"type": "material"
+		},
+		{
+			"name": "colorize_3",
+			"node_position": {
+				"x": 465,
+				"y": 33.25
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0,
+							"r": 0
+						},
+						{
+							"a": 1,
+							"b": 0.520833,
+							"g": 0.520833,
+							"pos": 1,
+							"r": 0.520833
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "blend_0",
+			"node_position": {
+				"x": 541,
+				"y": -82.75
+			},
+			"parameters": {
+				"amount": 0.4,
+				"blend_type": 2
+			},
+			"type": "blend"
+		},
+		{
+			"name": "warp_0",
+			"node_position": {
+				"x": 264,
+				"y": -13.75
+			},
+			"parameters": {
+				"amount": 0.4,
+				"eps": 0.045,
+				"epsilon": 0
+			},
+			"type": "warp"
+		},
+		{
+			"name": "blend_1",
+			"node_position": {
+				"x": 442,
+				"y": 175.25
+			},
+			"parameters": {
+				"amount": 0.5,
+				"blend_type": 0
+			},
+			"type": "blend"
+		},
+		{
+			"name": "normal_map_0",
+			"node_position": {
+				"x": 706,
+				"y": 95.25
+			},
+			"parameters": {
+				"amount": 0.35,
+				"param0": 11,
+				"param1": 11,
+				"param2": 1,
+				"size": 2
+			},
+			"type": "normal_map"
+		},
+		{
+			"name": "colorize_4",
+			"node_position": {
+				"x": 252,
+				"y": 178.25
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0,
+							"r": 1
+						},
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 1,
+							"r": 0
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "colorize",
+			"node_position": {
+				"x": 717.815796,
+				"y": 200.5625
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0,
+							"r": 1
+						},
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 1,
+							"r": 0
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		}
+	],
+	"parameters": {
+
+	},
+	"type": "graph"
+}

--- a/addons/material_maker/examples/floor1.ptex
+++ b/addons/material_maker/examples/floor1.ptex
@@ -1,1 +1,622 @@
-{"connections":[{"from":"normal_map_0","from_port":0,"to":"Material","to_port":4},{"from":"pattern_0","from_port":0,"to":"transform_0","to_port":0},{"from":"transform_0","from_port":0,"to":"transform_1","to_port":0},{"from":"transform_0","from_port":0,"to":"blend_0","to_port":0},{"from":"transform_1","from_port":0,"to":"blend_0","to_port":1},{"from":"blend_0","from_port":0,"to":"transform_2","to_port":0},{"from":"transform_2","from_port":0,"to":"colorize_2","to_port":0},{"from":"bricks_0","from_port":0,"to":"blend_1","to_port":0},{"from":"colorize_2","from_port":0,"to":"blend_1","to_port":1},{"from":"blend_1","from_port":0,"to":"blend_2","to_port":0},{"from":"transform_2","from_port":0,"to":"colorize_3","to_port":0},{"from":"colorize_3","from_port":0,"to":"blend_2","to_port":1},{"from":"perlin_1","from_port":0,"to":"colorize_5","to_port":0},{"from":"perlin_1","from_port":0,"to":"colorize_6","to_port":0},{"from":"colorize_5","from_port":0,"to":"blend_3","to_port":0},{"from":"colorize_6","from_port":0,"to":"blend_3","to_port":1},{"from":"blend_1","from_port":0,"to":"blend_3","to_port":2},{"from":"blend_2","from_port":0,"to":"blend_4","to_port":1},{"from":"perlin_1","from_port":0,"to":"blend_4","to_port":0},{"from":"uniform_0","from_port":0,"to":"Material","to_port":1},{"from":"blend_4","from_port":0,"to":"colorize_0","to_port":0},{"from":"perlin_1","from_port":0,"to":"colorize_1","to_port":0},{"from":"blend_5","from_port":0,"to":"Material","to_port":0},{"from":"colorize_3","from_port":0,"to":"blend_5","to_port":2},{"from":"blend_3","from_port":0,"to":"blend_5","to_port":1},{"from":"colorize_1","from_port":0,"to":"blend_5","to_port":0},{"from":"blend_4","from_port":0,"to":"colorize_4","to_port":0},{"from":"colorize_4","from_port":0,"to":"Material","to_port":2},{"from":"blend_4","from_port":0,"to":"normal_map_0","to_port":0},{"from":"colorize_0","from_port":0,"to":"Material","to_port":6}],"label":"Graph","name":"219","node_position":{"x":0,"y":0},"nodes":[{"name":"transform_1","node_position":{"x":-147,"y":781},"parameters":{"repeat":true,"rotate":90,"scale_x":1,"scale_y":1,"translate_x":0,"translate_y":0},"type":"transform"},{"name":"perlin_1","node_position":{"x":-146,"y":108},"parameters":{"iterations":7,"persistence":0.95,"scale_x":4,"scale_y":4},"type":"perlin"},{"name":"normal_map_0","node_position":{"x":665,"y":565},"parameters":{"amount":0.15,"param0":11,"param1":0.185,"size":5},"type":"normal_map"},{"name":"colorize_0","node_position":{"x":572.308655,"y":641},"parameters":{"gradient":{"points":[{"a":1,"b":1,"g":1,"pos":0,"r":1},{"a":1,"b":0,"g":0,"pos":1,"r":0}],"type":"Gradient"}},"type":"colorize"},{"name":"colorize_5","node_position":{"x":95,"y":85},"parameters":{"gradient":{"points":[{"a":1,"b":0,"g":0.071615,"pos":0,"r":0.208333},{"a":1,"b":0,"g":0.42041,"pos":0.936364,"r":0.640625}],"type":"Gradient"}},"type":"colorize"},{"name":"colorize_6","node_position":{"x":95,"y":159},"parameters":{"gradient":{"points":[{"a":1,"b":0.583333,"g":0.583333,"pos":0,"r":0.583333},{"a":1,"b":0.244792,"g":0.244792,"pos":1,"r":0.244792}],"type":"Gradient"}},"type":"colorize"},{"name":"colorize_1","node_position":{"x":101.308655,"y":249},"parameters":{"gradient":{"points":[{"a":1,"b":0,"g":0,"pos":0,"r":0.78125},{"a":1,"b":0,"g":0,"pos":1,"r":0.25}],"type":"Gradient"}},"type":"colorize"},{"name":"blend_1","node_position":{"x":115,"y":425},"parameters":{"amount":1,"blend_type":10},"type":"blend"},{"name":"blend_3","node_position":{"x":294.308655,"y":144},"parameters":{"amount":0.5,"blend_type":0},"type":"blend"},{"name":"blend_5","node_position":{"x":490.308655,"y":309},"parameters":{"amount":1,"blend_type":0},"type":"blend"},{"name":"colorize_4","node_position":{"x":701,"y":469},"parameters":{"gradient":{"points":[{"a":1,"b":1,"g":1,"pos":0,"r":1},{"a":1,"b":0.229167,"g":0.229167,"pos":1,"r":0.229167}],"type":"Gradient"}},"type":"colorize"},{"name":"bricks_0","node_position":{"x":-146,"y":455},"parameters":{"bevel":0.03,"columns":6,"mortar":0.01,"pattern":0,"repeat":1,"row_offset":0,"rows":6},"type":"bricks"},{"name":"transform_2","node_position":{"x":49,"y":634},"parameters":{"repeat":true,"rotate":0,"scale_x":0.5,"scale_y":0.5,"translate_x":0,"translate_y":0},"type":"transform"},{"name":"pattern_0","node_position":{"x":-358,"y":630},"parameters":{"mix":0,"x_scale":1,"x_wave":0,"y_scale":1,"y_wave":0},"type":"pattern"},{"name":"transform_0","node_position":{"x":-349,"y":730},"parameters":{"repeat":false,"rotate":0,"scale_x":0.5,"scale_y":1,"translate_x":0,"translate_y":0},"type":"transform"},{"name":"blend_0","node_position":{"x":-127,"y":673},"parameters":{"amount":1,"blend_type":9},"type":"blend"},{"name":"colorize_2","node_position":{"x":65,"y":549},"parameters":{"gradient":{"points":[{"a":1,"b":1,"g":1,"pos":0.7,"r":1},{"a":1,"b":0,"g":0,"pos":0.754545,"r":0}],"type":"Gradient"}},"type":"colorize"},{"name":"colorize_3","node_position":{"x":281,"y":638},"parameters":{"gradient":{"points":[{"a":1,"b":0,"g":0,"pos":0.736364,"r":0},{"a":1,"b":1,"g":1,"pos":0.790909,"r":1}],"type":"Gradient"}},"type":"colorize"},{"name":"blend_2","node_position":{"x":294,"y":514},"parameters":{"amount":1,"blend_type":9},"type":"blend"},{"name":"blend_4","node_position":{"x":469.308655,"y":463},"parameters":{"amount":0.072487,"blend_type":0},"type":"blend"},{"name":"Material","node_position":{"x":906,"y":387},"parameters":{"albedo_color":{"a":1,"b":1,"g":1,"r":1,"type":"Color"},"ao_light_affect":1,"depth_scale":0.05,"emission_energy":1,"metallic":1,"normal_scale":1,"resolution":1,"roughness":1,"size":11},"type":"material"},{"name":"uniform_0","node_position":{"x":700.308594,"y":404},"parameters":{"color":{"a":1,"b":0,"g":0,"r":0,"type":"Color"}},"type":"uniform"}],"parameters":{},"type":"graph"}
+{
+	"connections": [
+		{
+			"from": "normal_map_0",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 4
+		},
+		{
+			"from": "pattern_0",
+			"from_port": 0,
+			"to": "transform_0",
+			"to_port": 0
+		},
+		{
+			"from": "transform_0",
+			"from_port": 0,
+			"to": "transform_1",
+			"to_port": 0
+		},
+		{
+			"from": "transform_0",
+			"from_port": 0,
+			"to": "blend_0",
+			"to_port": 0
+		},
+		{
+			"from": "transform_1",
+			"from_port": 0,
+			"to": "blend_0",
+			"to_port": 1
+		},
+		{
+			"from": "blend_0",
+			"from_port": 0,
+			"to": "transform_2",
+			"to_port": 0
+		},
+		{
+			"from": "transform_2",
+			"from_port": 0,
+			"to": "colorize_2",
+			"to_port": 0
+		},
+		{
+			"from": "bricks_0",
+			"from_port": 0,
+			"to": "blend_1",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_2",
+			"from_port": 0,
+			"to": "blend_1",
+			"to_port": 1
+		},
+		{
+			"from": "blend_1",
+			"from_port": 0,
+			"to": "blend_2",
+			"to_port": 0
+		},
+		{
+			"from": "transform_2",
+			"from_port": 0,
+			"to": "colorize_3",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_3",
+			"from_port": 0,
+			"to": "blend_2",
+			"to_port": 1
+		},
+		{
+			"from": "perlin_1",
+			"from_port": 0,
+			"to": "colorize_5",
+			"to_port": 0
+		},
+		{
+			"from": "perlin_1",
+			"from_port": 0,
+			"to": "colorize_6",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_5",
+			"from_port": 0,
+			"to": "blend_3",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_6",
+			"from_port": 0,
+			"to": "blend_3",
+			"to_port": 1
+		},
+		{
+			"from": "blend_1",
+			"from_port": 0,
+			"to": "blend_3",
+			"to_port": 2
+		},
+		{
+			"from": "blend_2",
+			"from_port": 0,
+			"to": "blend_4",
+			"to_port": 1
+		},
+		{
+			"from": "perlin_1",
+			"from_port": 0,
+			"to": "blend_4",
+			"to_port": 0
+		},
+		{
+			"from": "uniform_0",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 1
+		},
+		{
+			"from": "blend_4",
+			"from_port": 0,
+			"to": "colorize_0",
+			"to_port": 0
+		},
+		{
+			"from": "perlin_1",
+			"from_port": 0,
+			"to": "colorize_1",
+			"to_port": 0
+		},
+		{
+			"from": "blend_5",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_3",
+			"from_port": 0,
+			"to": "blend_5",
+			"to_port": 2
+		},
+		{
+			"from": "blend_3",
+			"from_port": 0,
+			"to": "blend_5",
+			"to_port": 1
+		},
+		{
+			"from": "colorize_1",
+			"from_port": 0,
+			"to": "blend_5",
+			"to_port": 0
+		},
+		{
+			"from": "blend_4",
+			"from_port": 0,
+			"to": "colorize_4",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_4",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 2
+		},
+		{
+			"from": "blend_4",
+			"from_port": 0,
+			"to": "normal_map_0",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_0",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 6
+		}
+	],
+	"label": "Graph",
+	"name": "219",
+	"node_position": {
+		"x": 0,
+		"y": 0
+	},
+	"nodes": [
+		{
+			"name": "transform_1",
+			"node_position": {
+				"x": -147,
+				"y": 781
+			},
+			"parameters": {
+				"repeat": true,
+				"rotate": 90,
+				"scale_x": 1,
+				"scale_y": 1,
+				"translate_x": 0,
+				"translate_y": 0
+			},
+			"type": "transform"
+		},
+		{
+			"name": "perlin_1",
+			"node_position": {
+				"x": -146,
+				"y": 108
+			},
+			"parameters": {
+				"iterations": 7,
+				"persistence": 0.95,
+				"scale_x": 4,
+				"scale_y": 4
+			},
+			"type": "perlin"
+		},
+		{
+			"name": "normal_map_0",
+			"node_position": {
+				"x": 665,
+				"y": 565
+			},
+			"parameters": {
+				"amount": 0.15,
+				"param0": 11,
+				"param1": 11,
+				"param2": 1,
+				"size": 5
+			},
+			"type": "normal_map"
+		},
+		{
+			"name": "colorize_0",
+			"node_position": {
+				"x": 572.308655,
+				"y": 641
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0,
+							"r": 1
+						},
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 1,
+							"r": 0
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "colorize_5",
+			"node_position": {
+				"x": 95,
+				"y": 85
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0.071615,
+							"pos": 0,
+							"r": 0.208333
+						},
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0.42041,
+							"pos": 0.936364,
+							"r": 0.640625
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "colorize_6",
+			"node_position": {
+				"x": 95,
+				"y": 159
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0.583333,
+							"g": 0.583333,
+							"pos": 0,
+							"r": 0.583333
+						},
+						{
+							"a": 1,
+							"b": 0.244792,
+							"g": 0.244792,
+							"pos": 1,
+							"r": 0.244792
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "colorize_1",
+			"node_position": {
+				"x": 101.308655,
+				"y": 249
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0,
+							"r": 0.78125
+						},
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 1,
+							"r": 0.25
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "blend_1",
+			"node_position": {
+				"x": 115,
+				"y": 425
+			},
+			"parameters": {
+				"amount": 1,
+				"blend_type": 10
+			},
+			"type": "blend"
+		},
+		{
+			"name": "blend_3",
+			"node_position": {
+				"x": 294.308655,
+				"y": 144
+			},
+			"parameters": {
+				"amount": 0.5,
+				"blend_type": 0
+			},
+			"type": "blend"
+		},
+		{
+			"name": "blend_5",
+			"node_position": {
+				"x": 490.308655,
+				"y": 309
+			},
+			"parameters": {
+				"amount": 1,
+				"blend_type": 0
+			},
+			"type": "blend"
+		},
+		{
+			"name": "colorize_4",
+			"node_position": {
+				"x": 701,
+				"y": 469
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0,
+							"r": 1
+						},
+						{
+							"a": 1,
+							"b": 0.229167,
+							"g": 0.229167,
+							"pos": 1,
+							"r": 0.229167
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "bricks_0",
+			"node_position": {
+				"x": -146,
+				"y": 455
+			},
+			"parameters": {
+				"bevel": 0.03,
+				"columns": 6,
+				"mortar": 0.01,
+				"pattern": 0,
+				"repeat": 1,
+				"row_offset": 0,
+				"rows": 6
+			},
+			"type": "bricks"
+		},
+		{
+			"name": "transform_2",
+			"node_position": {
+				"x": 49,
+				"y": 634
+			},
+			"parameters": {
+				"repeat": true,
+				"rotate": 0,
+				"scale_x": 0.5,
+				"scale_y": 0.5,
+				"translate_x": 0,
+				"translate_y": 0
+			},
+			"type": "transform"
+		},
+		{
+			"name": "pattern_0",
+			"node_position": {
+				"x": -358,
+				"y": 630
+			},
+			"parameters": {
+				"mix": 0,
+				"x_scale": 1,
+				"x_wave": 0,
+				"y_scale": 1,
+				"y_wave": 0
+			},
+			"type": "pattern"
+		},
+		{
+			"name": "transform_0",
+			"node_position": {
+				"x": -349,
+				"y": 730
+			},
+			"parameters": {
+				"repeat": false,
+				"rotate": 0,
+				"scale_x": 0.5,
+				"scale_y": 1,
+				"translate_x": 0,
+				"translate_y": 0
+			},
+			"type": "transform"
+		},
+		{
+			"name": "blend_0",
+			"node_position": {
+				"x": -127,
+				"y": 673
+			},
+			"parameters": {
+				"amount": 1,
+				"blend_type": 9
+			},
+			"type": "blend"
+		},
+		{
+			"name": "colorize_2",
+			"node_position": {
+				"x": 65,
+				"y": 549
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0.7,
+							"r": 1
+						},
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0.754545,
+							"r": 0
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "colorize_3",
+			"node_position": {
+				"x": 281,
+				"y": 638
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0.736364,
+							"r": 0
+						},
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0.790909,
+							"r": 1
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "blend_2",
+			"node_position": {
+				"x": 294,
+				"y": 514
+			},
+			"parameters": {
+				"amount": 1,
+				"blend_type": 9
+			},
+			"type": "blend"
+		},
+		{
+			"name": "blend_4",
+			"node_position": {
+				"x": 469.308655,
+				"y": 463
+			},
+			"parameters": {
+				"amount": 0.072487,
+				"blend_type": 0
+			},
+			"type": "blend"
+		},
+		{
+			"name": "Material",
+			"node_position": {
+				"x": 906,
+				"y": 387
+			},
+			"parameters": {
+				"albedo_color": {
+					"a": 1,
+					"b": 1,
+					"g": 1,
+					"r": 1,
+					"type": "Color"
+				},
+				"ao_light_affect": 1,
+				"depth_scale": 0.05,
+				"emission_energy": 1,
+				"metallic": 1,
+				"normal_scale": 1,
+				"resolution": 1,
+				"roughness": 1,
+				"size": 11
+			},
+			"type": "material"
+		},
+		{
+			"name": "uniform_0",
+			"node_position": {
+				"x": 700.308594,
+				"y": 404
+			},
+			"parameters": {
+				"color": {
+					"a": 1,
+					"b": 0,
+					"g": 0,
+					"r": 0,
+					"type": "Color"
+				}
+			},
+			"type": "uniform"
+		}
+	],
+	"parameters": {
+
+	},
+	"type": "graph"
+}

--- a/addons/material_maker/examples/floor2.ptex
+++ b/addons/material_maker/examples/floor2.ptex
@@ -1,1 +1,228 @@
-{"connections":[{"from":"perlin_0","from_port":0,"to":"colorize_0","to_port":0},{"from":"colorize_0","from_port":0,"to":"blend_0","to_port":1},{"from":"bricks_0","from_port":0,"to":"blend_0","to_port":0},{"from":"blend_0","from_port":0,"to":"Material","to_port":0},{"from":"bricks_0","from_port":0,"to":"normal_map_0","to_port":0},{"from":"normal_map_0","from_port":0,"to":"Material","to_port":4},{"from":"colorize_1","from_port":0,"to":"Material","to_port":2},{"from":"blend_0","from_port":0,"to":"colorize_1","to_port":0},{"from":"uniform_0","from_port":0,"to":"Material","to_port":1}],"label":"Graph","name":"293","node_position":{"x":0,"y":0},"nodes":[{"name":"Material","node_position":{"x":773,"y":290},"parameters":{"albedo_color":{"a":1,"b":1,"g":1,"r":1,"type":"Color"},"ao_light_affect":1,"depth_scale":1,"emission_energy":1,"metallic":1,"normal_scale":1,"resolution":1,"roughness":1,"size":11},"type":"material"},{"name":"perlin_0","node_position":{"x":7,"y":263},"parameters":{"iterations":7,"persistence":0.85,"scale_x":8,"scale_y":8},"type":"perlin"},{"name":"bricks_0","node_position":{"x":242,"y":382},"parameters":{"bevel":0.01,"columns":4,"mortar":0.01,"pattern":0,"repeat":1,"row_offset":0,"rows":4},"type":"bricks"},{"name":"normal_map_0","node_position":{"x":516,"y":466},"parameters":{"amount":0.2,"param0":11,"param1":0.99,"size":2},"type":"normal_map"},{"name":"colorize_1","node_position":{"x":510,"y":386},"parameters":{"gradient":{"points":[{"a":1,"b":1,"g":1,"pos":0,"r":1},{"a":1,"b":0.484375,"g":0.484375,"pos":1,"r":0.484375}],"type":"Gradient"}},"type":"colorize"},{"name":"colorize_0","node_position":{"x":232,"y":286},"parameters":{"gradient":{"points":[{"a":1,"b":0.588542,"g":0.742839,"pos":0,"r":1},{"a":1,"b":1,"g":1,"pos":0.654545,"r":1}],"type":"Gradient"}},"type":"colorize"},{"name":"blend_0","node_position":{"x":419,"y":186},"parameters":{"amount":1,"blend_type":2},"type":"blend"},{"name":"uniform_0","node_position":{"x":563,"y":314},"parameters":{"color":{"a":1,"b":0.128906,"g":0.128906,"r":0.128906,"type":"Color"}},"type":"uniform"}],"parameters":{},"type":"graph"}
+{
+	"connections": [
+		{
+			"from": "perlin_0",
+			"from_port": 0,
+			"to": "colorize_0",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_0",
+			"from_port": 0,
+			"to": "blend_0",
+			"to_port": 1
+		},
+		{
+			"from": "bricks_0",
+			"from_port": 0,
+			"to": "blend_0",
+			"to_port": 0
+		},
+		{
+			"from": "blend_0",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 0
+		},
+		{
+			"from": "bricks_0",
+			"from_port": 0,
+			"to": "normal_map_0",
+			"to_port": 0
+		},
+		{
+			"from": "normal_map_0",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 4
+		},
+		{
+			"from": "colorize_1",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 2
+		},
+		{
+			"from": "blend_0",
+			"from_port": 0,
+			"to": "colorize_1",
+			"to_port": 0
+		},
+		{
+			"from": "uniform_0",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 1
+		}
+	],
+	"label": "Graph",
+	"name": "293",
+	"node_position": {
+		"x": 0,
+		"y": 0
+	},
+	"nodes": [
+		{
+			"name": "Material",
+			"node_position": {
+				"x": 773,
+				"y": 290
+			},
+			"parameters": {
+				"albedo_color": {
+					"a": 1,
+					"b": 1,
+					"g": 1,
+					"r": 1,
+					"type": "Color"
+				},
+				"ao_light_affect": 1,
+				"depth_scale": 1,
+				"emission_energy": 1,
+				"metallic": 1,
+				"normal_scale": 1,
+				"resolution": 1,
+				"roughness": 1,
+				"size": 11
+			},
+			"type": "material"
+		},
+		{
+			"name": "perlin_0",
+			"node_position": {
+				"x": 7,
+				"y": 263
+			},
+			"parameters": {
+				"iterations": 7,
+				"persistence": 0.85,
+				"scale_x": 8,
+				"scale_y": 8
+			},
+			"type": "perlin"
+		},
+		{
+			"name": "bricks_0",
+			"node_position": {
+				"x": 242,
+				"y": 382
+			},
+			"parameters": {
+				"bevel": 0.01,
+				"columns": 4,
+				"mortar": 0.01,
+				"pattern": 0,
+				"repeat": 1,
+				"row_offset": 0,
+				"rows": 4
+			},
+			"type": "bricks"
+		},
+		{
+			"name": "normal_map_0",
+			"node_position": {
+				"x": 516,
+				"y": 466
+			},
+			"parameters": {
+				"amount": 0.2,
+				"param0": 11,
+				"param1": 11,
+				"param2": 1,
+				"size": 2
+			},
+			"type": "normal_map"
+		},
+		{
+			"name": "colorize_1",
+			"node_position": {
+				"x": 510,
+				"y": 386
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0,
+							"r": 1
+						},
+						{
+							"a": 1,
+							"b": 0.484375,
+							"g": 0.484375,
+							"pos": 1,
+							"r": 0.484375
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "colorize_0",
+			"node_position": {
+				"x": 232,
+				"y": 286
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0.588542,
+							"g": 0.742839,
+							"pos": 0,
+							"r": 1
+						},
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0.654545,
+							"r": 1
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "blend_0",
+			"node_position": {
+				"x": 419,
+				"y": 186
+			},
+			"parameters": {
+				"amount": 1,
+				"blend_type": 2
+			},
+			"type": "blend"
+		},
+		{
+			"name": "uniform_0",
+			"node_position": {
+				"x": 563,
+				"y": 314
+			},
+			"parameters": {
+				"color": {
+					"a": 1,
+					"b": 0.128906,
+					"g": 0.128906,
+					"r": 0.128906,
+					"type": "Color"
+				}
+			},
+			"type": "uniform"
+		}
+	],
+	"parameters": {
+
+	},
+	"type": "graph"
+}

--- a/addons/material_maker/examples/grass_with_flowers.ptex
+++ b/addons/material_maker/examples/grass_with_flowers.ptex
@@ -1,1 +1,290 @@
-{"connections":[{"from":"perlin_0","from_port":0,"to":"colorize_0","to_port":0},{"from":"voronoi_0","from_port":0,"to":"colorize_1","to_port":0},{"from":"colorize_0","from_port":0,"to":"blend_0","to_port":0},{"from":"colorize_1","from_port":0,"to":"blend_0","to_port":2},{"from":"perlin_0","from_port":0,"to":"normal_map_0","to_port":0},{"from":"normal_map_0","from_port":0,"to":"Material","to_port":4},{"from":"voronoi_0","from_port":2,"to":"blend_0","to_port":1},{"from":"voronoi_0","from_port":0,"to":"colorize_2","to_port":0},{"from":"blend_0","from_port":0,"to":"blend_1","to_port":0},{"from":"blend_1","from_port":0,"to":"Material","to_port":0},{"from":"colorize_2","from_port":0,"to":"blend_1","to_port":2},{"from":"uniform_0","from_port":0,"to":"blend_1","to_port":1},{"from":"colorize_1","from_port":0,"to":"Material","to_port":2}],"label":"Graph","name":"253","node_position":{"x":0,"y":0},"nodes":[{"name":"colorize_0","node_position":{"x":335,"y":-261.75},"parameters":{"gradient":{"points":[{"a":1,"b":0.15682,"g":0.734375,"pos":0.445455,"r":0.247062},{"a":1,"b":0.112522,"g":0.317708,"pos":0.863636,"r":0.144582}],"type":"Gradient"}},"type":"colorize"},{"name":"Material","node_position":{"x":996,"y":22},"parameters":{"albedo_color":{"a":1,"b":1,"g":1,"r":1,"type":"Color"},"ao_light_affect":1,"depth_scale":1,"emission_energy":0,"metallic":0,"normal_scale":1,"resolution":1,"roughness":1,"size":11},"type":"material"},{"name":"normal_map_0","node_position":{"x":635,"y":142.25},"parameters":{"amount":0.8,"param0":11,"param1":0.25,"size":2},"type":"normal_map"},{"name":"colorize_1","node_position":{"x":524,"y":-26.75},"parameters":{"gradient":{"points":[{"a":1,"b":0,"g":0,"pos":0.245455,"r":0},{"a":1,"b":1,"g":1,"pos":0.436364,"r":1}],"type":"Gradient"}},"type":"colorize"},{"name":"colorize_2","node_position":{"x":413,"y":71.25},"parameters":{"gradient":{"points":[{"a":1,"b":0,"g":0,"pos":0.118182,"r":0},{"a":1,"b":1,"g":1,"pos":0.172727,"r":1}],"type":"Gradient"}},"type":"colorize"},{"name":"blend_1","node_position":{"x":826,"y":-119.75},"parameters":{"amount":1,"blend_type":0},"type":"blend"},{"name":"uniform_0","node_position":{"x":690,"y":-104},"parameters":{"color":{"a":1,"b":0,"g":0.984375,"r":1,"type":"Color"}},"type":"uniform"},{"name":"perlin_0","node_position":{"x":-25,"y":-27.75},"parameters":{"iterations":9,"persistence":0.8,"scale_x":6,"scale_y":6},"type":"perlin"},{"name":"voronoi_0","node_position":{"x":269,"y":-104.75},"parameters":{"intensity":1,"randomness":1,"scale_x":14,"scale_y":14},"type":"voronoi"},{"name":"blend_0","node_position":{"x":643,"y":-244.75},"parameters":{"amount":1,"blend_type":0},"type":"blend"}],"parameters":{},"type":"graph"}
+{
+	"connections": [
+		{
+			"from": "perlin_0",
+			"from_port": 0,
+			"to": "colorize_0",
+			"to_port": 0
+		},
+		{
+			"from": "voronoi_0",
+			"from_port": 0,
+			"to": "colorize_1",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_0",
+			"from_port": 0,
+			"to": "blend_0",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_1",
+			"from_port": 0,
+			"to": "blend_0",
+			"to_port": 2
+		},
+		{
+			"from": "perlin_0",
+			"from_port": 0,
+			"to": "normal_map_0",
+			"to_port": 0
+		},
+		{
+			"from": "normal_map_0",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 4
+		},
+		{
+			"from": "voronoi_0",
+			"from_port": 2,
+			"to": "blend_0",
+			"to_port": 1
+		},
+		{
+			"from": "voronoi_0",
+			"from_port": 0,
+			"to": "colorize_2",
+			"to_port": 0
+		},
+		{
+			"from": "blend_0",
+			"from_port": 0,
+			"to": "blend_1",
+			"to_port": 0
+		},
+		{
+			"from": "blend_1",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_2",
+			"from_port": 0,
+			"to": "blend_1",
+			"to_port": 2
+		},
+		{
+			"from": "uniform_0",
+			"from_port": 0,
+			"to": "blend_1",
+			"to_port": 1
+		},
+		{
+			"from": "colorize_1",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 2
+		}
+	],
+	"label": "Graph",
+	"name": "253",
+	"node_position": {
+		"x": 0,
+		"y": 0
+	},
+	"nodes": [
+		{
+			"name": "colorize_0",
+			"node_position": {
+				"x": 335,
+				"y": -261.75
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0.15682,
+							"g": 0.734375,
+							"pos": 0.445455,
+							"r": 0.247062
+						},
+						{
+							"a": 1,
+							"b": 0.112522,
+							"g": 0.317708,
+							"pos": 0.863636,
+							"r": 0.144582
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "Material",
+			"node_position": {
+				"x": 996,
+				"y": 22
+			},
+			"parameters": {
+				"albedo_color": {
+					"a": 1,
+					"b": 1,
+					"g": 1,
+					"r": 1,
+					"type": "Color"
+				},
+				"ao_light_affect": 1,
+				"depth_scale": 1,
+				"emission_energy": 0,
+				"metallic": 0,
+				"normal_scale": 1,
+				"resolution": 1,
+				"roughness": 1,
+				"size": 11
+			},
+			"type": "material"
+		},
+		{
+			"name": "normal_map_0",
+			"node_position": {
+				"x": 635,
+				"y": 142.25
+			},
+			"parameters": {
+				"amount": 0.8,
+				"param0": 11,
+				"param1": 11,
+				"param2": 1,
+				"size": 2
+			},
+			"type": "normal_map"
+		},
+		{
+			"name": "colorize_1",
+			"node_position": {
+				"x": 524,
+				"y": -26.75
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0.245455,
+							"r": 0
+						},
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0.436364,
+							"r": 1
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "colorize_2",
+			"node_position": {
+				"x": 413,
+				"y": 71.25
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0.118182,
+							"r": 0
+						},
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0.172727,
+							"r": 1
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "blend_1",
+			"node_position": {
+				"x": 826,
+				"y": -119.75
+			},
+			"parameters": {
+				"amount": 1,
+				"blend_type": 0
+			},
+			"type": "blend"
+		},
+		{
+			"name": "uniform_0",
+			"node_position": {
+				"x": 690,
+				"y": -104
+			},
+			"parameters": {
+				"color": {
+					"a": 1,
+					"b": 0,
+					"g": 0.984375,
+					"r": 1,
+					"type": "Color"
+				}
+			},
+			"type": "uniform"
+		},
+		{
+			"name": "perlin_0",
+			"node_position": {
+				"x": -25,
+				"y": -27.75
+			},
+			"parameters": {
+				"iterations": 9,
+				"persistence": 0.8,
+				"scale_x": 6,
+				"scale_y": 6
+			},
+			"type": "perlin"
+		},
+		{
+			"name": "voronoi_0",
+			"node_position": {
+				"x": 269,
+				"y": -104.75
+			},
+			"parameters": {
+				"intensity": 1,
+				"randomness": 1,
+				"scale_x": 14,
+				"scale_y": 14
+			},
+			"type": "voronoi"
+		},
+		{
+			"name": "blend_0",
+			"node_position": {
+				"x": 643,
+				"y": -244.75
+			},
+			"parameters": {
+				"amount": 1,
+				"blend_type": 0
+			},
+			"type": "blend"
+		}
+	],
+	"parameters": {
+
+	},
+	"type": "graph"
+}

--- a/addons/material_maker/examples/improved_brick.ptex
+++ b/addons/material_maker/examples/improved_brick.ptex
@@ -1,1 +1,812 @@
-{"connections":[{"from":"colorize","from_port":0,"to":"blend","to_port":0},{"from":"bricks","from_port":0,"to":"colorize_3","to_port":0},{"from":"uniform","from_port":0,"to":"blend_4","to_port":1},{"from":"colorize_8","from_port":0,"to":"blend_4","to_port":2},{"from":"perlin_3","from_port":0,"to":"colorize_8","to_port":0},{"from":"blend","from_port":0,"to":"blend_4","to_port":0},{"from":"blend_6","from_port":0,"to":"colorize","to_port":0},{"from":"perlin","from_port":0,"to":"colorize_4","to_port":0},{"from":"perlin_2","from_port":0,"to":"colorize_5","to_port":0},{"from":"colorize_2","from_port":0,"to":"blend_6","to_port":0},{"from":"perlin_4","from_port":0,"to":"colorize_9","to_port":0},{"from":"colorize_4","from_port":0,"to":"blend_2","to_port":1},{"from":"colorize_5","from_port":0,"to":"blend_2","to_port":0},{"from":"blend_2","from_port":0,"to":"colorize_2","to_port":0},{"from":"colorize_3","from_port":0,"to":"Material","to_port":6},{"from":"bricks_2","from_port":0,"to":"colorize_7","to_port":0},{"from":"blend_4","from_port":0,"to":"Material","to_port":0},{"from":"colorize_7","from_port":0,"to":"Material","to_port":5},{"from":"bricks","from_port":0,"to":"colorize_6","to_port":0},{"from":"blend_2","from_port":0,"to":"normal_map","to_port":0},{"from":"blend_2","from_port":0,"to":"blend_3","to_port":2},{"from":"colorize_6","from_port":0,"to":"normal_map_2","to_port":0},{"from":"normal_map_2","from_port":0,"to":"blend_3","to_port":0},{"from":"normal_map","from_port":0,"to":"blend_3","to_port":1},{"from":"bricks_2","from_port":1,"to":"blend_6","to_port":1},{"from":"bricks_2","from_port":0,"to":"colorize_10","to_port":0},{"from":"colorize_10","from_port":0,"to":"blend","to_port":2},{"from":"colorize_10","from_port":0,"to":"blend_7","to_port":2},{"from":"blend_3","from_port":0,"to":"blend_7","to_port":0},{"from":"normal_map_3","from_port":0,"to":"blend_7","to_port":1},{"from":"blend_7","from_port":0,"to":"Material","to_port":4},{"from":"colorize_9","from_port":0,"to":"blend","to_port":1},{"from":"colorize_9","from_port":0,"to":"normal_map_3","to_port":0}],"label":"Graph","name":"47","node_position":{"x":0,"y":0},"nodes":[{"name":"Material","node_position":{"x":620,"y":40},"parameters":{"albedo_color":{"a":1,"b":1,"g":1,"r":1,"type":"Color"},"ao_light_affect":1,"depth_scale":0.05,"emission_energy":1,"metallic":0,"normal_scale":1,"roughness":0.85,"size":11},"type":"material"},{"name":"bricks","node_position":{"x":-820,"y":100},"parameters":{"bevel":0,"columns":6,"mortar":0.087751,"pattern":1,"repeat":1,"row_offset":0.5,"rows":20},"type":"bricks"},{"name":"colorize","node_position":{"x":-240,"y":-60},"parameters":{"gradient":{"points":[{"a":1,"b":0.273875,"g":0.292765,"pos":0.476686,"r":0.529121},{"a":1,"b":0.185466,"g":0.193957,"pos":0.477339,"r":0.276042},{"a":1,"b":0.185466,"g":0.193957,"pos":0.733221,"r":0.276042},{"a":1,"b":0.566243,"g":0.625829,"pos":0.734721,"r":0.739583}],"type":"Gradient"}},"type":"colorize"},{"name":"blend","node_position":{"x":20,"y":-20},"parameters":{"amount":1,"blend_type":0},"type":"blend"},{"name":"colorize_3","node_position":{"x":-260,"y":200},"parameters":{"gradient":{"points":[{"a":1,"b":0.822917,"g":0.822917,"pos":0,"r":0.822917},{"a":1,"b":0.239583,"g":0.239583,"pos":1,"r":0.239583}],"type":"Gradient"}},"type":"colorize"},{"name":"perlin","node_position":{"x":-820,"y":340},"parameters":{"iterations":8,"persistence":0.5,"scale_x":16,"scale_y":16},"type":"perlin"},{"name":"colorize_4","node_position":{"x":-520,"y":360},"parameters":{"gradient":{"points":[{"a":0.898039,"b":0,"g":0,"pos":0.163636,"r":0},{"a":0,"b":0.984314,"g":0.984314,"pos":0.463636,"r":0.984314}],"type":"Gradient"}},"type":"colorize"},{"name":"perlin_2","node_position":{"x":-820,"y":500},"parameters":{"iterations":8,"persistence":0.5,"scale_x":128,"scale_y":128},"type":"perlin"},{"name":"colorize_5","node_position":{"x":-520,"y":480},"parameters":{"gradient":{"points":[{"a":0.588235,"b":0,"g":0,"pos":0.272727,"r":0},{"a":0,"b":1,"g":1,"pos":0.407774,"r":1}],"type":"Gradient"}},"type":"colorize"},{"name":"perlin_3","node_position":{"x":-820,"y":700},"parameters":{"iterations":8,"persistence":0.8,"scale_x":16,"scale_y":16},"type":"perlin"},{"name":"blend_4","node_position":{"x":-160,"y":660},"parameters":{"amount":1,"blend_type":0},"type":"blend"},{"name":"uniform","node_position":{"x":-444.088257,"y":600.058838},"parameters":{"color":{"a":1,"b":0.047059,"g":0.078431,"r":0.12549,"type":"Color"}},"type":"uniform"},{"name":"colorize_8","node_position":{"x":-500,"y":700},"parameters":{"gradient":{"points":[{"a":1,"b":0.302083,"g":0.302083,"pos":0,"r":0.302083},{"a":1,"b":1,"g":1,"pos":0.710145,"r":1}],"type":"Gradient"}},"type":"colorize"},{"name":"colorize_7","node_position":{"x":-240,"y":-200},"parameters":{"gradient":{"points":[{"a":1,"b":1,"g":1,"pos":0.559601,"r":1},{"a":1,"b":0.286458,"g":0.286458,"pos":0.781818,"r":0.286458},{"a":1,"b":1,"g":1,"pos":1,"r":1}],"type":"Gradient"}},"type":"colorize"},{"name":"comment","node_position":{"x":-1405.656738,"y":-1153.276611},"parameters":{"size":4},"size":{"x":264.319916,"y":165.399994},"text":"Realistic Bricks by Rafe Hall\n\nProcedural brick material that supports brick color, wear, ambient occlusion, grime, and depth.\n\nTODO: Edge wear, plaster and better layering.","type":"comment"},{"name":"perlin_4","node_position":{"x":-1080,"y":0},"parameters":{"iterations":8,"persistence":1,"scale_x":4,"scale_y":4},"type":"perlin"},{"name":"blend_6","node_position":{"x":-540,"y":-40},"parameters":{"amount":1,"blend_type":0},"type":"blend"},{"name":"colorize_2","node_position":{"x":-520,"y":200},"parameters":{"gradient":{"points":[{"a":1,"b":0,"g":0,"pos":0.715167,"r":0},{"a":0,"b":1,"g":1,"pos":0.715269,"r":1}],"type":"Gradient"}},"type":"colorize"},{"name":"colorize_9","node_position":{"x":-820,"y":0},"parameters":{"gradient":{"points":[{"a":1,"b":0.354167,"g":0.354167,"pos":0.209091,"r":0.354167},{"a":1,"b":0.536458,"g":0.536458,"pos":0.5,"r":0.536458},{"a":1,"b":0.166667,"g":0.166667,"pos":0.936364,"r":0.166667}],"type":"Gradient"}},"type":"colorize"},{"name":"blend_2","node_position":{"x":-260,"y":400},"parameters":{"amount":1,"blend_type":0},"type":"blend"},{"name":"bricks_2","node_position":{"x":-820,"y":-240},"parameters":{"bevel":0.087751,"columns":6,"mortar":0,"pattern":1,"repeat":1,"row_offset":0.5,"rows":20},"type":"bricks"},{"name":"normal_map","node_position":{"x":20,"y":400},"parameters":{"amount":0.5,"param0":11,"param1":1,"size":4},"type":"normal_map"},{"name":"colorize_6","node_position":{"x":-260,"y":280},"parameters":{"gradient":{"points":[{"a":1,"b":0,"g":0,"pos":0,"r":0},{"a":1,"b":1,"g":1,"pos":1,"r":1}],"type":"Gradient"}},"type":"colorize"},{"name":"blend_3","node_position":{"x":280,"y":260},"parameters":{"amount":1,"blend_type":0},"type":"blend"},{"name":"normal_map_2","node_position":{"x":-20,"y":260},"parameters":{"amount":0.5,"param0":11,"param1":1,"size":4},"type":"normal_map"},{"name":"colorize_10","node_position":{"x":-520,"y":-140},"parameters":{"gradient":{"points":[{"a":1,"b":0,"g":0,"pos":0.710909,"r":0},{"a":1,"b":1,"g":1,"pos":0.72,"r":1}],"type":"Gradient"}},"type":"colorize"},{"name":"normal_map_3","node_position":{"x":60,"y":-240},"parameters":{"amount":0.5,"param0":11,"param1":0.42,"size":4},"type":"normal_map"},{"name":"blend_7","node_position":{"x":309,"y":-128},"parameters":{"amount":1,"blend_type":0},"type":"blend"},{"name":"comment_2","node_position":{"x":-202.672852,"y":93.677933},"parameters":{"size":4},"size":{"x":371,"y":49},"text":"Improved bricks, by Rafe Hall (aka MrDiamondGold)","type":"comment"}],"parameters":{},"type":"graph"}
+{
+	"connections": [
+		{
+			"from": "colorize",
+			"from_port": 0,
+			"to": "blend",
+			"to_port": 0
+		},
+		{
+			"from": "bricks",
+			"from_port": 0,
+			"to": "colorize_3",
+			"to_port": 0
+		},
+		{
+			"from": "uniform",
+			"from_port": 0,
+			"to": "blend_4",
+			"to_port": 1
+		},
+		{
+			"from": "colorize_8",
+			"from_port": 0,
+			"to": "blend_4",
+			"to_port": 2
+		},
+		{
+			"from": "perlin_3",
+			"from_port": 0,
+			"to": "colorize_8",
+			"to_port": 0
+		},
+		{
+			"from": "blend",
+			"from_port": 0,
+			"to": "blend_4",
+			"to_port": 0
+		},
+		{
+			"from": "blend_6",
+			"from_port": 0,
+			"to": "colorize",
+			"to_port": 0
+		},
+		{
+			"from": "perlin",
+			"from_port": 0,
+			"to": "colorize_4",
+			"to_port": 0
+		},
+		{
+			"from": "perlin_2",
+			"from_port": 0,
+			"to": "colorize_5",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_2",
+			"from_port": 0,
+			"to": "blend_6",
+			"to_port": 0
+		},
+		{
+			"from": "perlin_4",
+			"from_port": 0,
+			"to": "colorize_9",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_4",
+			"from_port": 0,
+			"to": "blend_2",
+			"to_port": 1
+		},
+		{
+			"from": "colorize_5",
+			"from_port": 0,
+			"to": "blend_2",
+			"to_port": 0
+		},
+		{
+			"from": "blend_2",
+			"from_port": 0,
+			"to": "colorize_2",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_3",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 6
+		},
+		{
+			"from": "bricks_2",
+			"from_port": 0,
+			"to": "colorize_7",
+			"to_port": 0
+		},
+		{
+			"from": "blend_4",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_7",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 5
+		},
+		{
+			"from": "bricks",
+			"from_port": 0,
+			"to": "colorize_6",
+			"to_port": 0
+		},
+		{
+			"from": "blend_2",
+			"from_port": 0,
+			"to": "normal_map",
+			"to_port": 0
+		},
+		{
+			"from": "blend_2",
+			"from_port": 0,
+			"to": "blend_3",
+			"to_port": 2
+		},
+		{
+			"from": "colorize_6",
+			"from_port": 0,
+			"to": "normal_map_2",
+			"to_port": 0
+		},
+		{
+			"from": "normal_map_2",
+			"from_port": 0,
+			"to": "blend_3",
+			"to_port": 0
+		},
+		{
+			"from": "normal_map",
+			"from_port": 0,
+			"to": "blend_3",
+			"to_port": 1
+		},
+		{
+			"from": "bricks_2",
+			"from_port": 1,
+			"to": "blend_6",
+			"to_port": 1
+		},
+		{
+			"from": "bricks_2",
+			"from_port": 0,
+			"to": "colorize_10",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_10",
+			"from_port": 0,
+			"to": "blend",
+			"to_port": 2
+		},
+		{
+			"from": "colorize_10",
+			"from_port": 0,
+			"to": "blend_7",
+			"to_port": 2
+		},
+		{
+			"from": "blend_3",
+			"from_port": 0,
+			"to": "blend_7",
+			"to_port": 0
+		},
+		{
+			"from": "normal_map_3",
+			"from_port": 0,
+			"to": "blend_7",
+			"to_port": 1
+		},
+		{
+			"from": "blend_7",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 4
+		},
+		{
+			"from": "colorize_9",
+			"from_port": 0,
+			"to": "blend",
+			"to_port": 1
+		},
+		{
+			"from": "colorize_9",
+			"from_port": 0,
+			"to": "normal_map_3",
+			"to_port": 0
+		}
+	],
+	"label": "Graph",
+	"name": "47",
+	"node_position": {
+		"x": 0,
+		"y": 0
+	},
+	"nodes": [
+		{
+			"name": "Material",
+			"node_position": {
+				"x": 620,
+				"y": 40
+			},
+			"parameters": {
+				"albedo_color": {
+					"a": 1,
+					"b": 1,
+					"g": 1,
+					"r": 1,
+					"type": "Color"
+				},
+				"ao_light_affect": 1,
+				"depth_scale": 0.05,
+				"emission_energy": 1,
+				"metallic": 0,
+				"normal_scale": 1,
+				"roughness": 0.85,
+				"size": 11
+			},
+			"type": "material"
+		},
+		{
+			"name": "bricks",
+			"node_position": {
+				"x": -820,
+				"y": 100
+			},
+			"parameters": {
+				"bevel": 0,
+				"columns": 6,
+				"mortar": 0.087751,
+				"pattern": 1,
+				"repeat": 1,
+				"row_offset": 0.5,
+				"rows": 20
+			},
+			"type": "bricks"
+		},
+		{
+			"name": "colorize",
+			"node_position": {
+				"x": -240,
+				"y": -60
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0.273875,
+							"g": 0.292765,
+							"pos": 0.476686,
+							"r": 0.529121
+						},
+						{
+							"a": 1,
+							"b": 0.185466,
+							"g": 0.193957,
+							"pos": 0.477339,
+							"r": 0.276042
+						},
+						{
+							"a": 1,
+							"b": 0.185466,
+							"g": 0.193957,
+							"pos": 0.733221,
+							"r": 0.276042
+						},
+						{
+							"a": 1,
+							"b": 0.566243,
+							"g": 0.625829,
+							"pos": 0.734721,
+							"r": 0.739583
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "blend",
+			"node_position": {
+				"x": 20,
+				"y": -20
+			},
+			"parameters": {
+				"amount": 1,
+				"blend_type": 0
+			},
+			"type": "blend"
+		},
+		{
+			"name": "colorize_3",
+			"node_position": {
+				"x": -260,
+				"y": 200
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0.822917,
+							"g": 0.822917,
+							"pos": 0,
+							"r": 0.822917
+						},
+						{
+							"a": 1,
+							"b": 0.239583,
+							"g": 0.239583,
+							"pos": 1,
+							"r": 0.239583
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "perlin",
+			"node_position": {
+				"x": -820,
+				"y": 340
+			},
+			"parameters": {
+				"iterations": 8,
+				"persistence": 0.5,
+				"scale_x": 16,
+				"scale_y": 16
+			},
+			"type": "perlin"
+		},
+		{
+			"name": "colorize_4",
+			"node_position": {
+				"x": -520,
+				"y": 360
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 0.898039,
+							"b": 0,
+							"g": 0,
+							"pos": 0.163636,
+							"r": 0
+						},
+						{
+							"a": 0,
+							"b": 0.984314,
+							"g": 0.984314,
+							"pos": 0.463636,
+							"r": 0.984314
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "perlin_2",
+			"node_position": {
+				"x": -820,
+				"y": 500
+			},
+			"parameters": {
+				"iterations": 8,
+				"persistence": 0.5,
+				"scale_x": 128,
+				"scale_y": 128
+			},
+			"type": "perlin"
+		},
+		{
+			"name": "colorize_5",
+			"node_position": {
+				"x": -520,
+				"y": 480
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 0.588235,
+							"b": 0,
+							"g": 0,
+							"pos": 0.272727,
+							"r": 0
+						},
+						{
+							"a": 0,
+							"b": 1,
+							"g": 1,
+							"pos": 0.407774,
+							"r": 1
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "perlin_3",
+			"node_position": {
+				"x": -820,
+				"y": 700
+			},
+			"parameters": {
+				"iterations": 8,
+				"persistence": 0.8,
+				"scale_x": 16,
+				"scale_y": 16
+			},
+			"type": "perlin"
+		},
+		{
+			"name": "blend_4",
+			"node_position": {
+				"x": -160,
+				"y": 660
+			},
+			"parameters": {
+				"amount": 1,
+				"blend_type": 0
+			},
+			"type": "blend"
+		},
+		{
+			"name": "uniform",
+			"node_position": {
+				"x": -444.088257,
+				"y": 600.058838
+			},
+			"parameters": {
+				"color": {
+					"a": 1,
+					"b": 0.047059,
+					"g": 0.078431,
+					"r": 0.12549,
+					"type": "Color"
+				}
+			},
+			"type": "uniform"
+		},
+		{
+			"name": "colorize_8",
+			"node_position": {
+				"x": -500,
+				"y": 700
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0.302083,
+							"g": 0.302083,
+							"pos": 0,
+							"r": 0.302083
+						},
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0.710145,
+							"r": 1
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "colorize_7",
+			"node_position": {
+				"x": -240,
+				"y": -200
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0.559601,
+							"r": 1
+						},
+						{
+							"a": 1,
+							"b": 0.286458,
+							"g": 0.286458,
+							"pos": 0.781818,
+							"r": 0.286458
+						},
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 1,
+							"r": 1
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "comment",
+			"node_position": {
+				"x": -1405.656738,
+				"y": -1153.276611
+			},
+			"parameters": {
+				"size": 4
+			},
+			"size": {
+				"x": 264.319916,
+				"y": 165.399994
+			},
+			"text": "Realistic Bricks by Rafe Hall\n\nProcedural brick material that supports brick color, wear, ambient occlusion, grime, and depth.\n\nTODO: Edge wear, plaster and better layering.",
+			"type": "comment"
+		},
+		{
+			"name": "perlin_4",
+			"node_position": {
+				"x": -1080,
+				"y": 0
+			},
+			"parameters": {
+				"iterations": 8,
+				"persistence": 1,
+				"scale_x": 4,
+				"scale_y": 4
+			},
+			"type": "perlin"
+		},
+		{
+			"name": "blend_6",
+			"node_position": {
+				"x": -540,
+				"y": -40
+			},
+			"parameters": {
+				"amount": 1,
+				"blend_type": 0
+			},
+			"type": "blend"
+		},
+		{
+			"name": "colorize_2",
+			"node_position": {
+				"x": -520,
+				"y": 200
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0.715167,
+							"r": 0
+						},
+						{
+							"a": 0,
+							"b": 1,
+							"g": 1,
+							"pos": 0.715269,
+							"r": 1
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "colorize_9",
+			"node_position": {
+				"x": -820,
+				"y": 0
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0.354167,
+							"g": 0.354167,
+							"pos": 0.209091,
+							"r": 0.354167
+						},
+						{
+							"a": 1,
+							"b": 0.536458,
+							"g": 0.536458,
+							"pos": 0.5,
+							"r": 0.536458
+						},
+						{
+							"a": 1,
+							"b": 0.166667,
+							"g": 0.166667,
+							"pos": 0.936364,
+							"r": 0.166667
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "blend_2",
+			"node_position": {
+				"x": -260,
+				"y": 400
+			},
+			"parameters": {
+				"amount": 1,
+				"blend_type": 0
+			},
+			"type": "blend"
+		},
+		{
+			"name": "bricks_2",
+			"node_position": {
+				"x": -820,
+				"y": -240
+			},
+			"parameters": {
+				"bevel": 0.087751,
+				"columns": 6,
+				"mortar": 0,
+				"pattern": 1,
+				"repeat": 1,
+				"row_offset": 0.5,
+				"rows": 20
+			},
+			"type": "bricks"
+		},
+		{
+			"name": "normal_map",
+			"node_position": {
+				"x": 20,
+				"y": 400
+			},
+			"parameters": {
+				"amount": 0.5,
+				"param0": 11,
+				"param1": 11,
+				"param2": 1,
+				"size": 4
+			},
+			"type": "normal_map"
+		},
+		{
+			"name": "colorize_6",
+			"node_position": {
+				"x": -260,
+				"y": 280
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0,
+							"r": 0
+						},
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 1,
+							"r": 1
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "blend_3",
+			"node_position": {
+				"x": 280,
+				"y": 260
+			},
+			"parameters": {
+				"amount": 1,
+				"blend_type": 0
+			},
+			"type": "blend"
+		},
+		{
+			"name": "normal_map_2",
+			"node_position": {
+				"x": -20,
+				"y": 260
+			},
+			"parameters": {
+				"amount": 0.5,
+				"param0": 11,
+				"param1": 11,
+				"param2": 1,
+				"size": 4
+			},
+			"type": "normal_map"
+		},
+		{
+			"name": "colorize_10",
+			"node_position": {
+				"x": -520,
+				"y": -140
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0.710909,
+							"r": 0
+						},
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0.72,
+							"r": 1
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "normal_map_3",
+			"node_position": {
+				"x": 60,
+				"y": -240
+			},
+			"parameters": {
+				"amount": 0.5,
+				"param0": 11,
+				"param1": 11,
+				"param2": 1,
+				"size": 4
+			},
+			"type": "normal_map"
+		},
+		{
+			"name": "blend_7",
+			"node_position": {
+				"x": 309,
+				"y": -128
+			},
+			"parameters": {
+				"amount": 1,
+				"blend_type": 0
+			},
+			"type": "blend"
+		},
+		{
+			"name": "comment_2",
+			"node_position": {
+				"x": -202.672852,
+				"y": 93.677933
+			},
+			"parameters": {
+				"size": 4
+			},
+			"size": {
+				"x": 371,
+				"y": 49
+			},
+			"text": "Improved bricks, by Rafe Hall (aka MrDiamondGold)",
+			"type": "comment"
+		}
+	],
+	"parameters": {
+
+	},
+	"type": "graph"
+}

--- a/addons/material_maker/examples/lava.ptex
+++ b/addons/material_maker/examples/lava.ptex
@@ -1,1 +1,349 @@
-{"connections":[{"from":"perlin_0","from_port":0,"to":"blend_0","to_port":0},{"from":"blend_0","from_port":0,"to":"colorize_0","to_port":0},{"from":"colorize_0","from_port":0,"to":"Material","to_port":0},{"from":"perlin_0","from_port":0,"to":"warp_0","to_port":1},{"from":"voronoi_0","from_port":0,"to":"warp_0","to_port":0},{"from":"warp_0","from_port":0,"to":"blend_0","to_port":1},{"from":"warp_0","from_port":0,"to":"colorize_1","to_port":0},{"from":"warp_0","from_port":0,"to":"colorize_2","to_port":0},{"from":"colorize_2","from_port":0,"to":"Material","to_port":2},{"from":"warp_0","from_port":0,"to":"normal_map_0","to_port":0},{"from":"normal_map_0","from_port":0,"to":"Material","to_port":4},{"from":"colorize_1","from_port":0,"to":"Material","to_port":3},{"from":"colorize_2","from_port":0,"to":"Material","to_port":1},{"from":"colorize_3","from_port":0,"to":"Material","to_port":5},{"from":"warp_0","from_port":0,"to":"colorize_3","to_port":0},{"from":"colorize_2","from_port":0,"to":"Material","to_port":6}],"label":"Graph","name":"408","node_position":{"x":0,"y":0},"nodes":[{"name":"Material","node_position":{"x":956,"y":271},"parameters":{"albedo_color":{"a":1,"b":1,"g":1,"r":1,"type":"Color"},"ao_light_affect":1,"depth_scale":0.45,"emission_energy":2,"metallic":1,"normal_scale":1,"resolution":1,"roughness":1,"size":11},"type":"material"},{"name":"colorize_0","node_position":{"x":666,"y":27},"parameters":{"gradient":{"points":[{"a":1,"b":0.479167,"g":0.479167,"pos":0.045455,"r":0.479167},{"a":1,"b":0.875,"g":0.875,"pos":0.3,"r":0.875},{"a":1,"b":0.442708,"g":0.442708,"pos":0.518182,"r":0.442708},{"a":1,"b":0.069093,"g":0.069093,"pos":0.818182,"r":0.069093},{"a":1,"b":0.40625,"g":0.40625,"pos":1,"r":0.40625}],"type":"Gradient"}},"type":"colorize"},{"name":"colorize_2","node_position":{"x":653,"y":140.5},"parameters":{"gradient":{"points":[{"a":1,"b":1,"g":1,"pos":0.272727,"r":1},{"a":1,"b":0,"g":0,"pos":0.563636,"r":0}],"type":"Gradient"}},"type":"colorize"},{"name":"colorize_1","node_position":{"x":646,"y":223},"parameters":{"gradient":{"points":[{"a":1,"b":0,"g":0.765625,"pos":0,"r":1},{"a":1,"b":0,"g":0,"pos":0.154545,"r":1},{"a":1,"b":0,"g":0,"pos":0.245455,"r":0}],"type":"Gradient"}},"type":"colorize"},{"name":"normal_map_0","node_position":{"x":658,"y":309.5},"parameters":{"amount":0.9,"param0":11,"param1":0.99,"size":2},"type":"normal_map"},{"name":"colorize_3","node_position":{"x":658,"y":404.25},"parameters":{"gradient":{"points":[{"a":1,"b":0.345455,"g":0.345455,"pos":0,"r":0.345455},{"a":1,"b":0,"g":0,"pos":1,"r":0}],"type":"Gradient"}},"type":"colorize"},{"name":"blend_0","node_position":{"x":475,"y":-30},"parameters":{"amount":0.83125,"blend_type":0},"type":"blend"},{"name":"warp_0","node_position":{"x":338,"y":196},"parameters":{"amount":0.3,"eps":0.045,"epsilon":0},"type":"warp"},{"name":"voronoi_0","node_position":{"x":130,"y":299},"parameters":{"intensity":0.55,"randomness":1,"scale_x":6,"scale_y":6},"type":"voronoi"},{"name":"perlin_0","node_position":{"x":190,"y":-14},"parameters":{"iterations":8,"persistence":0.75,"scale_x":4,"scale_y":4},"type":"perlin"}],"parameters":{},"type":"graph"}
+{
+	"connections": [
+		{
+			"from": "perlin_0",
+			"from_port": 0,
+			"to": "blend_0",
+			"to_port": 0
+		},
+		{
+			"from": "blend_0",
+			"from_port": 0,
+			"to": "colorize_0",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_0",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 0
+		},
+		{
+			"from": "perlin_0",
+			"from_port": 0,
+			"to": "warp_0",
+			"to_port": 1
+		},
+		{
+			"from": "voronoi_0",
+			"from_port": 0,
+			"to": "warp_0",
+			"to_port": 0
+		},
+		{
+			"from": "warp_0",
+			"from_port": 0,
+			"to": "blend_0",
+			"to_port": 1
+		},
+		{
+			"from": "warp_0",
+			"from_port": 0,
+			"to": "colorize_1",
+			"to_port": 0
+		},
+		{
+			"from": "warp_0",
+			"from_port": 0,
+			"to": "colorize_2",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_2",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 2
+		},
+		{
+			"from": "warp_0",
+			"from_port": 0,
+			"to": "normal_map_0",
+			"to_port": 0
+		},
+		{
+			"from": "normal_map_0",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 4
+		},
+		{
+			"from": "colorize_1",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 3
+		},
+		{
+			"from": "colorize_2",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 1
+		},
+		{
+			"from": "colorize_3",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 5
+		},
+		{
+			"from": "warp_0",
+			"from_port": 0,
+			"to": "colorize_3",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_2",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 6
+		}
+	],
+	"label": "Graph",
+	"name": "408",
+	"node_position": {
+		"x": 0,
+		"y": 0
+	},
+	"nodes": [
+		{
+			"name": "Material",
+			"node_position": {
+				"x": 956,
+				"y": 271
+			},
+			"parameters": {
+				"albedo_color": {
+					"a": 1,
+					"b": 1,
+					"g": 1,
+					"r": 1,
+					"type": "Color"
+				},
+				"ao_light_affect": 1,
+				"depth_scale": 0.45,
+				"emission_energy": 2,
+				"metallic": 1,
+				"normal_scale": 1,
+				"resolution": 1,
+				"roughness": 1,
+				"size": 11
+			},
+			"type": "material"
+		},
+		{
+			"name": "colorize_0",
+			"node_position": {
+				"x": 666,
+				"y": 27
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0.479167,
+							"g": 0.479167,
+							"pos": 0.045455,
+							"r": 0.479167
+						},
+						{
+							"a": 1,
+							"b": 0.875,
+							"g": 0.875,
+							"pos": 0.3,
+							"r": 0.875
+						},
+						{
+							"a": 1,
+							"b": 0.442708,
+							"g": 0.442708,
+							"pos": 0.518182,
+							"r": 0.442708
+						},
+						{
+							"a": 1,
+							"b": 0.069093,
+							"g": 0.069093,
+							"pos": 0.818182,
+							"r": 0.069093
+						},
+						{
+							"a": 1,
+							"b": 0.40625,
+							"g": 0.40625,
+							"pos": 1,
+							"r": 0.40625
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "colorize_2",
+			"node_position": {
+				"x": 653,
+				"y": 140.5
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0.272727,
+							"r": 1
+						},
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0.563636,
+							"r": 0
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "colorize_1",
+			"node_position": {
+				"x": 646,
+				"y": 223
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0.765625,
+							"pos": 0,
+							"r": 1
+						},
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0.154545,
+							"r": 1
+						},
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0.245455,
+							"r": 0
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "normal_map_0",
+			"node_position": {
+				"x": 658,
+				"y": 309.5
+			},
+			"parameters": {
+				"amount": 0.9,
+				"param0": 11,
+				"param1": 11,
+				"param2": 1,
+				"size": 2
+			},
+			"type": "normal_map"
+		},
+		{
+			"name": "colorize_3",
+			"node_position": {
+				"x": 658,
+				"y": 404.25
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0.345455,
+							"g": 0.345455,
+							"pos": 0,
+							"r": 0.345455
+						},
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 1,
+							"r": 0
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "blend_0",
+			"node_position": {
+				"x": 475,
+				"y": -30
+			},
+			"parameters": {
+				"amount": 0.83125,
+				"blend_type": 0
+			},
+			"type": "blend"
+		},
+		{
+			"name": "warp_0",
+			"node_position": {
+				"x": 338,
+				"y": 196
+			},
+			"parameters": {
+				"amount": 0.3,
+				"eps": 0.045,
+				"epsilon": 0
+			},
+			"type": "warp"
+		},
+		{
+			"name": "voronoi_0",
+			"node_position": {
+				"x": 130,
+				"y": 299
+			},
+			"parameters": {
+				"intensity": 0.55,
+				"randomness": 1,
+				"scale_x": 6,
+				"scale_y": 6
+			},
+			"type": "voronoi"
+		},
+		{
+			"name": "perlin_0",
+			"node_position": {
+				"x": 190,
+				"y": -14
+			},
+			"parameters": {
+				"iterations": 8,
+				"persistence": 0.75,
+				"scale_x": 4,
+				"scale_y": 4
+			},
+			"type": "perlin"
+		}
+	],
+	"parameters": {
+
+	},
+	"type": "graph"
+}

--- a/addons/material_maker/examples/mandala.ptex
+++ b/addons/material_maker/examples/mandala.ptex
@@ -1,1 +1,2140 @@
-{"connections":[{"from":"graph","from_port":0,"to":"Material","to_port":4},{"from":"graph","from_port":1,"to":"Material","to_port":6},{"from":"graph_2","from_port":0,"to":"graph_4","to_port":0},{"from":"graph_3","from_port":0,"to":"graph_4","to_port":1},{"from":"transform","from_port":0,"to":"colorize","to_port":0},{"from":"colorize","from_port":0,"to":"graph_4","to_port":2},{"from":"graph_7","from_port":0,"to":"transform_2","to_port":0},{"from":"transform_2","from_port":0,"to":"transform_2_2","to_port":0},{"from":"transform_2_2","from_port":0,"to":"colorize_2","to_port":0},{"from":"colorize_2","from_port":0,"to":"graph_4","to_port":3},{"from":"perlin","from_port":0,"to":"colorize_3","to_port":0},{"from":"colorize_3","from_port":0,"to":"Material","to_port":0},{"from":"graph_4","from_port":0,"to":"graph","to_port":0},{"from":"graph_5","from_port":0,"to":"transform_3","to_port":0},{"from":"transform_3","from_port":0,"to":"transform","to_port":0}],"label":"Graph","name":"39","node_position":{"x":0,"y":0},"nodes":[{"name":"Material","node_position":{"x":-465,"y":71},"parameters":{"albedo_color":{"a":1,"b":0.509804,"g":0.509804,"r":0.509804,"type":"Color"},"ao_light_affect":1,"depth_scale":0.15,"emission_energy":1,"metallic":0.25,"normal_scale":1,"roughness":1,"size":11},"type":"material"},{"connections":[{"from":"gen_inputs","from_port":0,"to":"colorize_4","to_port":0},{"from":"colorize_4","from_port":0,"to":"gen_outputs","to_port":1},{"from":"normal_map","from_port":0,"to":"gen_outputs","to_port":0},{"from":"gen_inputs","from_port":0,"to":"normal_map","to_port":0}],"label":"Normal+Depth","name":"graph","node_position":{"x":-620.577881,"y":109.055542},"nodes":[{"name":"colorize_4","node_position":{"x":-43.577881,"y":5.555542},"parameters":{"gradient":{"points":[{"a":1,"b":1,"g":1,"pos":0,"r":1},{"a":1,"b":0,"g":0,"pos":1,"r":0}],"type":"Gradient"}},"type":"colorize"},{"name":"gen_inputs","node_position":{"x":-205.577881,"y":-30.944458},"parameters":{},"ports":[{"name":"port0","type":"rgba"}],"type":"ios"},{"name":"gen_outputs","node_position":{"x":193.422119,"y":-24.944458},"parameters":{},"ports":[{"name":"port0","type":"rgba"},{"name":"port1","type":"rgba"}],"type":"ios"},{"name":"normal_map","node_position":{"x":-54.577881,"y":-82.444458},"parameters":{"param0":11,"param1":0.995},"type":"normal_map"}],"parameters":{},"type":"graph"},{"connections":[{"from":"shape","from_port":0,"to":"transform","to_port":0},{"from":"transform","from_port":0,"to":"transform_2","to_port":0},{"from":"transform_2","from_port":0,"to":"colorize","to_port":0},{"from":"colorize","from_port":0,"to":"colorize_3","to_port":0},{"from":"colorize_3","from_port":0,"to":"gen_outputs","to_port":0}],"label":"Grid","name":"graph_2","node_position":{"x":-888.524597,"y":-77},"nodes":[{"name":"shape","node_position":{"x":-549.5,"y":-97.5},"parameters":{"edge":1,"radius":1,"shape":1,"sides":8},"type":"shape"},{"name":"transform","node_position":{"x":-580.5,"y":118.5},"parameters":{"repeat":false,"rotate":0,"scale_x":1.2,"scale_y":1.2,"translate_x":0,"translate_y":0},"type":"transform"},{"name":"transform_2","node_position":{"x":-579.5,"y":312},"parameters":{"repeat":true,"rotate":0,"scale_x":0.3,"scale_y":0.3,"translate_x":0.45,"translate_y":0.45},"type":"transform"},{"name":"colorize","node_position":{"x":-287.5,"y":144.5},"parameters":{"gradient":{"points":[{"a":1,"b":0,"g":0,"pos":0.072727,"r":0},{"a":1,"b":1,"g":1,"pos":0.163636,"r":1},{"a":1,"b":0,"g":0,"pos":0.263636,"r":0}],"type":"Gradient"}},"type":"colorize"},{"name":"colorize_3","node_position":{"x":-288.623047,"y":217.5},"parameters":{"gradient":{"points":[{"a":1,"b":0,"g":0,"pos":0,"r":0},{"a":1,"b":0.472727,"g":0.472727,"pos":0.345454,"r":0.472727},{"a":1,"b":0.566168,"g":0.566168,"pos":0.690909,"r":0.566168},{"a":1,"b":0.786458,"g":0.786458,"pos":1,"r":0.786458}],"type":"Gradient"}},"type":"colorize"},{"name":"gen_outputs","node_position":{"x":-55.5,"y":225},"parameters":{},"ports":[{"name":"port0","type":"rgba"}],"type":"ios"}],"parameters":{},"type":"graph"},{"connections":[{"from":"pattern","from_port":0,"to":"colorize_2","to_port":0},{"from":"colorize_2","from_port":0,"to":"colorize_4","to_port":0},{"from":"colorize_4","from_port":0,"to":"gen_outputs","to_port":0}],"label":"Frame","name":"graph_3","node_position":{"x":-919.184326,"y":75.568512},"nodes":[{"name":"colorize_4","node_position":{"x":-558.307007,"y":443.205566},"parameters":{"gradient":{"points":[{"a":1,"b":0,"g":0,"pos":0,"r":0},{"a":1,"b":0.772727,"g":0.772727,"pos":0.118182,"r":0.772727},{"a":1,"b":1,"g":1,"pos":0.836364,"r":1},{"a":1,"b":1,"g":1,"pos":1,"r":1}],"type":"Gradient"}},"type":"colorize"},{"name":"colorize_2","node_position":{"x":-559.623047,"y":376},"parameters":{"gradient":{"points":[{"a":1,"b":1,"g":1,"pos":0,"r":1},{"a":1,"b":0,"g":0,"pos":0.053488,"r":0}],"type":"Gradient"}},"type":"colorize"},{"name":"pattern","node_position":{"x":-580.623047,"y":274.5},"parameters":{"mix":3,"x_scale":1,"x_wave":0,"y_scale":1,"y_wave":0},"type":"pattern"},{"name":"gen_outputs","node_position":{"x":-258.307007,"y":364.568512},"parameters":{},"ports":[{"name":"port0","type":"rgba"}],"type":"ios"}],"parameters":{},"type":"graph"},{"name":"transform","node_position":{"x":-1138.172852,"y":24.856049},"parameters":{"repeat":true,"rotate":0,"scale_x":0.3,"scale_y":0.3,"translate_x":0.15,"translate_y":0.15},"type":"transform"},{"name":"colorize","node_position":{"x":-1127.944092,"y":216.956055},"parameters":{"gradient":{"points":[{"a":1,"b":0,"g":0,"pos":0,"r":0},{"a":1,"b":0.588542,"g":0.588542,"pos":1,"r":0.588542}],"type":"Gradient"}},"type":"colorize"},{"connections":[{"from":"graph_4","from_port":0,"to":"graph","to_port":0},{"from":"graph","from_port":0,"to":"gen_outputs","to_port":0}],"label":"Flower1","name":"graph_5","node_position":{"x":-1105.223755,"y":-43.758514},"nodes":[{"connections":[{"from":"pattern","from_port":0,"to":"colorize","to_port":0},{"from":"colorize","from_port":0,"to":"transform","to_port":4},{"from":"shape","from_port":0,"to":"colorize_2","to_port":0},{"from":"colorize_2","from_port":0,"to":"transform","to_port":0},{"from":"transform","from_port":0,"to":"blend","to_port":1},{"from":"pattern","from_port":0,"to":"colorize_3","to_port":0},{"from":"colorize_3","from_port":0,"to":"blend","to_port":0},{"from":"pattern_2","from_port":0,"to":"colorize_4","to_port":0},{"from":"blend","from_port":0,"to":"blend_2","to_port":1},{"from":"blend_2","from_port":0,"to":"gen_outputs","to_port":0},{"from":"colorize_4","from_port":0,"to":"mirror","to_port":0},{"from":"mirror","from_port":0,"to":"blend_2","to_port":0}],"label":"Petal","name":"graph_4","node_position":{"x":-861.847046,"y":454.074829},"nodes":[{"name":"shape","node_position":{"x":-580.281982,"y":291.324799},"parameters":{"edge":1,"radius":0.845361,"shape":0,"sides":6},"type":"shape"},{"name":"pattern","node_position":{"x":-646.281982,"y":452.324799},"parameters":{"mix":0,"x_scale":1,"x_wave":4,"y_scale":1,"y_wave":3},"type":"pattern"},{"name":"colorize","node_position":{"x":-603.912109,"y":551.324829},"parameters":{"gradient":{"points":[{"a":1,"b":0.572917,"g":0.572917,"pos":0,"r":0.572917},{"a":1,"b":0.848958,"g":0.848958,"pos":0.210696,"r":0.848958},{"a":1,"b":0.734375,"g":0.734375,"pos":0.677225,"r":0.734375},{"a":1,"b":0.536458,"g":0.536458,"pos":1,"r":0.536458}],"type":"Gradient"}},"type":"colorize"},{"name":"transform","node_position":{"x":-630.912109,"y":611.324829},"parameters":{"repeat":false,"rotate":0,"scale_x":1,"scale_y":1,"translate_x":0,"translate_y":0},"type":"transform"},{"name":"gen_outputs","node_position":{"x":113.718018,"y":533.074829},"parameters":{},"ports":[{"name":"port0","type":"rgba"}],"type":"ios"},{"name":"colorize_2","node_position":{"x":-599.834045,"y":394.574799},"parameters":{"gradient":{"points":[{"a":1,"b":0,"g":0,"pos":0,"r":0},{"a":1,"b":1,"g":1,"pos":0.172727,"r":1},{"a":1,"b":0.755208,"g":0.755208,"pos":1,"r":0.755208}],"type":"Gradient"}},"type":"colorize"},{"name":"blend","node_position":{"x":-142.870667,"y":465.158081},"parameters":{"amount":1,"blend_type":2},"type":"blend"},{"name":"colorize_3","node_position":{"x":-346.870667,"y":413.158081},"parameters":{"gradient":{"points":[{"a":1,"b":1,"g":1,"pos":0,"r":1},{"a":1,"b":0,"g":0,"pos":1,"r":0}],"type":"Gradient"}},"type":"colorize"},{"name":"pattern_2","node_position":{"x":-364.870667,"y":744.158081},"parameters":{"mix":0,"x_scale":1,"x_wave":1,"y_scale":1,"y_wave":0},"type":"pattern"},{"name":"colorize_4","node_position":{"x":-329.870667,"y":684.158081},"parameters":{"gradient":{"points":[{"a":1,"b":1,"g":1,"pos":0.636364,"r":1},{"a":1,"b":0.6,"g":0.6,"pos":0.936364,"r":0.6},{"a":1,"b":0.296875,"g":0.296875,"pos":1,"r":0.296875}],"type":"Gradient"}},"type":"colorize"},{"name":"blend_2","node_position":{"x":-141.870667,"y":561.158081},"parameters":{"amount":1,"blend_type":2},"type":"blend"},{"name":"mirror","node_position":{"x":-316.870667,"y":611.158081},"parameters":{"direction":1,"offset":0.505},"type":"mirror"}],"parameters":{},"type":"graph"},{"name":"gen_outputs","node_position":{"x":-459.912109,"y":453.241486},"parameters":{},"ports":[{"name":"port0","type":"rgba"}],"type":"ios"},{"connections":[{"from":"gen_inputs","from_port":0,"to":"transform_2","to_port":0},{"from":"blend","from_port":0,"to":"gen_outputs","to_port":0},{"from":"shape","from_port":0,"to":"colorize","to_port":0},{"from":"colorize","from_port":0,"to":"blend","to_port":0},{"from":"transform_2","from_port":0,"to":"kaleidoscope_2","to_port":0},{"from":"kaleidoscope_2","from_port":0,"to":"blend","to_port":1}],"label":"Flower Builder","name":"graph","node_position":{"x":-700.567932,"y":449.269257},"nodes":[{"name":"blend","node_position":{"x":-369.145874,"y":397.741486},"parameters":{"amount":1,"blend_type":9},"type":"blend"},{"name":"transform_2","node_position":{"x":-651.912109,"y":396.324829},"parameters":{"repeat":false,"rotate":0,"scale_x":0.5,"scale_y":0.5,"translate_x":0,"translate_y":-0.2},"type":"transform"},{"name":"shape","node_position":{"x":-604.145874,"y":279.741486},"parameters":{"edge":1,"radius":0.264981,"shape":0,"sides":6},"type":"shape"},{"name":"colorize","node_position":{"x":-435.145874,"y":290.741486},"parameters":{"gradient":{"points":[{"a":1,"b":0,"g":0,"pos":0,"r":0},{"a":1,"b":0.456684,"g":0.456684,"pos":0.2,"r":0.456684},{"a":1,"b":0.602823,"g":0.602823,"pos":0.318182,"r":0.602823},{"a":1,"b":0.732,"g":0.732,"pos":0.463636,"r":0.732},{"a":1,"b":0.9,"g":0.9,"pos":0.681818,"r":0.9},{"a":1,"b":1,"g":1,"pos":1,"r":1}],"type":"Gradient"}},"type":"colorize"},{"name":"gen_parameters","node_position":{"x":-600.145874,"y":146.741486},"parameters":{"param0":7,"param1":0.264981},"type":"remote","widgets":[{"label":"Unnamed","linked_widgets":[{"node":"kaleidoscope_2","widget":"count"}],"type":"linked_control"},{"label":"Unnamed","linked_widgets":[{"node":"shape","widget":"radius"}],"type":"linked_control"}]},{"name":"gen_inputs","node_position":{"x":-951.912109,"y":356.269257},"parameters":{},"ports":[{"name":"port0","type":"rgba"}],"type":"ios"},{"name":"gen_outputs","node_position":{"x":-69.145874,"y":356.269257},"parameters":{},"ports":[{"name":"port0","type":"rgba"}],"type":"ios"},{"name":"kaleidoscope_2","node_position":{"x":-615.808228,"y":593.956787},"parameters":{"count":7,"direction":0,"offset":0},"type":"kaleidoscope"}],"parameters":{"param0":7,"param1":0.264981},"type":"graph"}],"parameters":{},"type":"graph"},{"name":"transform_2","node_position":{"x":-1063.855835,"y":370.619873},"parameters":{"repeat":false,"rotate":0,"scale_x":0.4,"scale_y":0.4,"translate_x":0,"translate_y":0},"type":"transform"},{"name":"transform_2_2","node_position":{"x":-832.475098,"y":370.055542},"parameters":{"repeat":true,"rotate":0,"scale_x":0.3,"scale_y":0.3,"translate_x":0,"translate_y":0},"type":"transform"},{"connections":[{"from":"graph_4","from_port":0,"to":"graph_6","to_port":0},{"from":"graph_6","from_port":0,"to":"gen_outputs","to_port":0}],"label":"Flower2","name":"graph_7","node_position":{"x":-952.17395,"y":292.142639},"nodes":[{"connections":[{"from":"pattern","from_port":0,"to":"colorize","to_port":0},{"from":"colorize","from_port":0,"to":"transform","to_port":4},{"from":"shape","from_port":0,"to":"colorize_2","to_port":0},{"from":"colorize_2","from_port":0,"to":"transform","to_port":0},{"from":"transform","from_port":0,"to":"blend","to_port":1},{"from":"pattern","from_port":0,"to":"colorize_3","to_port":0},{"from":"colorize_3","from_port":0,"to":"blend","to_port":0},{"from":"pattern_2","from_port":0,"to":"colorize_4","to_port":0},{"from":"blend","from_port":0,"to":"blend_2","to_port":1},{"from":"blend_2","from_port":0,"to":"gen_outputs","to_port":0},{"from":"colorize_4","from_port":0,"to":"mirror","to_port":0},{"from":"mirror","from_port":0,"to":"blend_2","to_port":0}],"label":"Petal","name":"graph_4","node_position":{"x":-635.313538,"y":599.04541},"nodes":[{"name":"shape","node_position":{"x":-552.281982,"y":258.324799},"parameters":{"edge":1,"radius":0.845361,"shape":0,"sides":6},"type":"shape"},{"name":"pattern","node_position":{"x":-618.281982,"y":419.324799},"parameters":{"mix":0,"x_scale":1,"x_wave":4,"y_scale":1,"y_wave":3},"type":"pattern"},{"name":"colorize","node_position":{"x":-575.912109,"y":518.324829},"parameters":{"gradient":{"points":[{"a":1,"b":0.572917,"g":0.572917,"pos":0,"r":0.572917},{"a":1,"b":0.876823,"g":0.876823,"pos":0.092589,"r":0.876823},{"a":1,"b":1,"g":1,"pos":0.283423,"r":1},{"a":1,"b":0.776042,"g":0.776042,"pos":0.677225,"r":0.776042},{"a":1,"b":0.536458,"g":0.536458,"pos":1,"r":0.536458}],"type":"Gradient"}},"type":"colorize"},{"name":"transform","node_position":{"x":-602.912109,"y":578.324829},"parameters":{"repeat":false,"rotate":0,"scale_x":1,"scale_y":1,"translate_x":0,"translate_y":0},"type":"transform"},{"name":"gen_outputs","node_position":{"x":154.718018,"y":556.074829},"parameters":{},"ports":[{"name":"port0","type":"rgba"}],"type":"ios"},{"name":"colorize_2","node_position":{"x":-571.834045,"y":361.574799},"parameters":{"gradient":{"points":[{"a":1,"b":0,"g":0,"pos":0,"r":0},{"a":1,"b":1,"g":1,"pos":0.172727,"r":1},{"a":1,"b":0.755208,"g":0.755208,"pos":1,"r":0.755208}],"type":"Gradient"}},"type":"colorize"},{"name":"blend","node_position":{"x":-118.870667,"y":440.158081},"parameters":{"amount":1,"blend_type":2},"type":"blend"},{"name":"colorize_3","node_position":{"x":-346.870667,"y":413.158081},"parameters":{"gradient":{"points":[{"a":1,"b":1,"g":1,"pos":0,"r":1},{"a":1,"b":0,"g":0,"pos":1,"r":0}],"type":"Gradient"}},"type":"colorize"},{"name":"pattern_2","node_position":{"x":-380.870667,"y":786.158081},"parameters":{"mix":0,"x_scale":1,"x_wave":1,"y_scale":1,"y_wave":0},"type":"pattern"},{"name":"colorize_4","node_position":{"x":-332.870667,"y":723.158081},"parameters":{"gradient":{"points":[{"a":1,"b":1,"g":1,"pos":0.636364,"r":1},{"a":1,"b":0.6,"g":0.6,"pos":0.936364,"r":0.6},{"a":1,"b":0.296875,"g":0.296875,"pos":1,"r":0.296875}],"type":"Gradient"}},"type":"colorize"},{"name":"blend_2","node_position":{"x":-117.870667,"y":536.158081},"parameters":{"amount":1,"blend_type":2},"type":"blend"},{"name":"mirror","node_position":{"x":-330.870667,"y":635.158081},"parameters":{"direction":1,"offset":0.505},"type":"mirror"}],"parameters":{},"type":"graph"},{"connections":[{"from":"gen_inputs","from_port":0,"to":"transform_2","to_port":0},{"from":"blend","from_port":0,"to":"gen_outputs","to_port":0},{"from":"shape","from_port":0,"to":"colorize","to_port":0},{"from":"colorize","from_port":0,"to":"blend","to_port":0},{"from":"transform_2","from_port":0,"to":"kaleidoscope","to_port":0},{"from":"kaleidoscope","from_port":0,"to":"blend","to_port":1}],"label":"Flower Builder","name":"graph_6","node_position":{"x":-477.034424,"y":593.239868},"nodes":[{"name":"blend","node_position":{"x":-369.145874,"y":397.741486},"parameters":{"amount":1,"blend_type":9},"type":"blend"},{"name":"transform_2","node_position":{"x":-651.912109,"y":396.324829},"parameters":{"repeat":false,"rotate":0,"scale_x":0.5,"scale_y":0.5,"translate_x":0,"translate_y":-0.2},"type":"transform"},{"name":"shape","node_position":{"x":-604.145874,"y":279.741486},"parameters":{"edge":1,"radius":0.330915,"shape":0,"sides":6},"type":"shape"},{"name":"colorize","node_position":{"x":-435.145874,"y":290.741486},"parameters":{"gradient":{"points":[{"a":1,"b":0,"g":0,"pos":0,"r":0},{"a":1,"b":0.456684,"g":0.456684,"pos":0.2,"r":0.456684},{"a":1,"b":0.602823,"g":0.602823,"pos":0.318182,"r":0.602823},{"a":1,"b":0.732,"g":0.732,"pos":0.463636,"r":0.732},{"a":1,"b":0.9,"g":0.9,"pos":0.681818,"r":0.9},{"a":1,"b":1,"g":1,"pos":1,"r":1}],"type":"Gradient"}},"type":"colorize"},{"name":"gen_parameters","node_position":{"x":-650.145874,"y":158.741486},"parameters":{"param0":4,"param1":0.330915},"type":"remote","widgets":[{"label":"Unnamed","linked_widgets":[{"node":"kaleidoscope","widget":"count"}],"type":"linked_control"},{"label":"Unnamed","linked_widgets":[{"node":"shape","widget":"radius"}],"type":"linked_control"}]},{"name":"gen_inputs","node_position":{"x":-951.912109,"y":356.269257},"parameters":{},"ports":[{"name":"port0","type":"rgba"}],"type":"ios"},{"name":"gen_outputs","node_position":{"x":-69.145874,"y":356.269257},"parameters":{},"ports":[{"name":"port0","type":"rgba"}],"type":"ios"},{"name":"kaleidoscope","node_position":{"x":-612.808228,"y":591.706787},"parameters":{"count":4,"direction":0,"offset":0},"type":"kaleidoscope"}],"parameters":{"param0":4,"param1":0.330915},"type":"graph"},{"name":"gen_outputs","node_position":{"x":-177.034424,"y":596.142639},"parameters":{},"ports":[{"name":"port0","type":"rgba"}],"type":"ios"}],"parameters":{},"type":"graph"},{"connections":[{"from":"gen_inputs","from_port":0,"to":"blend","to_port":0},{"from":"gen_inputs","from_port":1,"to":"blend","to_port":1},{"from":"gen_inputs","from_port":2,"to":"blend_2","to_port":0},{"from":"blend_2","from_port":0,"to":"blend_3","to_port":1},{"from":"blend_3","from_port":0,"to":"gen_outputs","to_port":0},{"from":"blend","from_port":0,"to":"blend_2","to_port":1},{"from":"gen_inputs","from_port":3,"to":"blend_3","to_port":0}],"label":"Lighten4","name":"graph_4","node_position":{"x":-769.075928,"y":86.158661},"nodes":[{"name":"blend_2","node_position":{"x":14.684723,"y":336.856049},"parameters":{"amount":1,"blend_type":9},"type":"blend"},{"name":"blend","node_position":{"x":14.376953,"y":246.5},"parameters":{"amount":1,"blend_type":9},"type":"blend"},{"name":"blend_3","node_position":{"x":14.710419,"y":426.119873},"parameters":{"amount":1,"blend_type":9},"type":"blend"},{"name":"gen_inputs","node_position":{"x":-227.623047,"y":380.158661},"parameters":{},"ports":[{"name":"port0","type":"rgba"},{"name":"port1","type":"rgba"},{"name":"port2","type":"rgba"},{"name":"port3","type":"rgba"}],"type":"ios"},{"name":"gen_outputs","node_position":{"x":367.684723,"y":417.158661},"parameters":{},"ports":[{"name":"port0","type":"rgba"}],"type":"ios"}],"parameters":{},"type":"graph"},{"name":"colorize_2","node_position":{"x":-819.609863,"y":296.695862},"parameters":{"gradient":{"points":[{"a":1,"b":0,"g":0,"pos":0,"r":0},{"a":1,"b":0.630208,"g":0.630208,"pos":1,"r":0.630208}],"type":"Gradient"}},"type":"colorize"},{"name":"perlin","node_position":{"x":-730.287415,"y":-51.888901},"parameters":{"iterations":7,"persistence":0.5,"scale_x":16,"scale_y":16},"type":"perlin"},{"name":"colorize_3","node_position":{"x":-494.287415,"y":-28.888901},"parameters":{"gradient":{"points":[{"a":1,"b":0.666667,"g":0.666667,"pos":0,"r":0.666667},{"a":1,"b":1,"g":1,"pos":1,"r":1}],"type":"Gradient"}},"type":"colorize"},{"name":"transform_3","node_position":{"x":-1369.070557,"y":25.255157},"parameters":{"repeat":false,"rotate":0,"scale_x":1.15,"scale_y":1.15,"translate_x":0,"translate_y":0},"type":"transform"}],"parameters":{},"type":"graph"}
+{
+	"connections": [
+		{
+			"from": "graph",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 4
+		},
+		{
+			"from": "graph",
+			"from_port": 1,
+			"to": "Material",
+			"to_port": 6
+		},
+		{
+			"from": "graph_2",
+			"from_port": 0,
+			"to": "graph_4",
+			"to_port": 0
+		},
+		{
+			"from": "graph_3",
+			"from_port": 0,
+			"to": "graph_4",
+			"to_port": 1
+		},
+		{
+			"from": "transform",
+			"from_port": 0,
+			"to": "colorize",
+			"to_port": 0
+		},
+		{
+			"from": "colorize",
+			"from_port": 0,
+			"to": "graph_4",
+			"to_port": 2
+		},
+		{
+			"from": "graph_7",
+			"from_port": 0,
+			"to": "transform_2",
+			"to_port": 0
+		},
+		{
+			"from": "transform_2",
+			"from_port": 0,
+			"to": "transform_2_2",
+			"to_port": 0
+		},
+		{
+			"from": "transform_2_2",
+			"from_port": 0,
+			"to": "colorize_2",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_2",
+			"from_port": 0,
+			"to": "graph_4",
+			"to_port": 3
+		},
+		{
+			"from": "perlin",
+			"from_port": 0,
+			"to": "colorize_3",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_3",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 0
+		},
+		{
+			"from": "graph_4",
+			"from_port": 0,
+			"to": "graph",
+			"to_port": 0
+		},
+		{
+			"from": "graph_5",
+			"from_port": 0,
+			"to": "transform_3",
+			"to_port": 0
+		},
+		{
+			"from": "transform_3",
+			"from_port": 0,
+			"to": "transform",
+			"to_port": 0
+		}
+	],
+	"label": "Graph",
+	"name": "39",
+	"node_position": {
+		"x": 0,
+		"y": 0
+	},
+	"nodes": [
+		{
+			"name": "Material",
+			"node_position": {
+				"x": -465,
+				"y": 71
+			},
+			"parameters": {
+				"albedo_color": {
+					"a": 1,
+					"b": 0.509804,
+					"g": 0.509804,
+					"r": 0.509804,
+					"type": "Color"
+				},
+				"ao_light_affect": 1,
+				"depth_scale": 0.15,
+				"emission_energy": 1,
+				"metallic": 0.25,
+				"normal_scale": 1,
+				"roughness": 1,
+				"size": 11
+			},
+			"type": "material"
+		},
+		{
+			"connections": [
+				{
+					"from": "gen_inputs",
+					"from_port": 0,
+					"to": "colorize_4",
+					"to_port": 0
+				},
+				{
+					"from": "colorize_4",
+					"from_port": 0,
+					"to": "gen_outputs",
+					"to_port": 1
+				},
+				{
+					"from": "normal_map",
+					"from_port": 0,
+					"to": "gen_outputs",
+					"to_port": 0
+				},
+				{
+					"from": "gen_inputs",
+					"from_port": 0,
+					"to": "normal_map",
+					"to_port": 0
+				}
+			],
+			"label": "Normal+Depth",
+			"name": "graph",
+			"node_position": {
+				"x": -620.577881,
+				"y": 109.055542
+			},
+			"nodes": [
+				{
+					"name": "colorize_4",
+					"node_position": {
+						"x": -43.577881,
+						"y": 5.555542
+					},
+					"parameters": {
+						"gradient": {
+							"points": [
+								{
+									"a": 1,
+									"b": 1,
+									"g": 1,
+									"pos": 0,
+									"r": 1
+								},
+								{
+									"a": 1,
+									"b": 0,
+									"g": 0,
+									"pos": 1,
+									"r": 0
+								}
+							],
+							"type": "Gradient"
+						}
+					},
+					"type": "colorize"
+				},
+				{
+					"name": "gen_inputs",
+					"node_position": {
+						"x": -205.577881,
+						"y": -30.944458
+					},
+					"parameters": {
+
+					},
+					"ports": [
+						{
+							"name": "port0",
+							"type": "rgba"
+						}
+					],
+					"type": "ios"
+				},
+				{
+					"name": "gen_outputs",
+					"node_position": {
+						"x": 193.422119,
+						"y": -24.944458
+					},
+					"parameters": {
+
+					},
+					"ports": [
+						{
+							"name": "port0",
+							"type": "rgba"
+						},
+						{
+							"name": "port1",
+							"type": "rgba"
+						}
+					],
+					"type": "ios"
+				},
+				{
+					"name": "normal_map",
+					"node_position": {
+						"x": -54.577881,
+						"y": -82.444458
+					},
+					"parameters": {
+						"amount": 0.3,
+						"param0": 11,
+						"param1": 0.995,
+						"param2": 1,
+						"size": 4
+					},
+					"type": "normal_map"
+				}
+			],
+			"parameters": {
+
+			},
+			"type": "graph"
+		},
+		{
+			"connections": [
+				{
+					"from": "shape",
+					"from_port": 0,
+					"to": "transform",
+					"to_port": 0
+				},
+				{
+					"from": "transform",
+					"from_port": 0,
+					"to": "transform_2",
+					"to_port": 0
+				},
+				{
+					"from": "transform_2",
+					"from_port": 0,
+					"to": "colorize",
+					"to_port": 0
+				},
+				{
+					"from": "colorize",
+					"from_port": 0,
+					"to": "colorize_3",
+					"to_port": 0
+				},
+				{
+					"from": "colorize_3",
+					"from_port": 0,
+					"to": "gen_outputs",
+					"to_port": 0
+				}
+			],
+			"label": "Grid",
+			"name": "graph_2",
+			"node_position": {
+				"x": -888.524597,
+				"y": -77
+			},
+			"nodes": [
+				{
+					"name": "shape",
+					"node_position": {
+						"x": -549.5,
+						"y": -97.5
+					},
+					"parameters": {
+						"edge": 1,
+						"radius": 1,
+						"shape": 1,
+						"sides": 8
+					},
+					"type": "shape"
+				},
+				{
+					"name": "transform",
+					"node_position": {
+						"x": -580.5,
+						"y": 118.5
+					},
+					"parameters": {
+						"repeat": false,
+						"rotate": 0,
+						"scale_x": 1.2,
+						"scale_y": 1.2,
+						"translate_x": 0,
+						"translate_y": 0
+					},
+					"type": "transform"
+				},
+				{
+					"name": "transform_2",
+					"node_position": {
+						"x": -579.5,
+						"y": 312
+					},
+					"parameters": {
+						"repeat": true,
+						"rotate": 0,
+						"scale_x": 0.3,
+						"scale_y": 0.3,
+						"translate_x": 0.45,
+						"translate_y": 0.45
+					},
+					"type": "transform"
+				},
+				{
+					"name": "colorize",
+					"node_position": {
+						"x": -287.5,
+						"y": 144.5
+					},
+					"parameters": {
+						"gradient": {
+							"points": [
+								{
+									"a": 1,
+									"b": 0,
+									"g": 0,
+									"pos": 0.072727,
+									"r": 0
+								},
+								{
+									"a": 1,
+									"b": 1,
+									"g": 1,
+									"pos": 0.163636,
+									"r": 1
+								},
+								{
+									"a": 1,
+									"b": 0,
+									"g": 0,
+									"pos": 0.263636,
+									"r": 0
+								}
+							],
+							"type": "Gradient"
+						}
+					},
+					"type": "colorize"
+				},
+				{
+					"name": "colorize_3",
+					"node_position": {
+						"x": -288.623047,
+						"y": 217.5
+					},
+					"parameters": {
+						"gradient": {
+							"points": [
+								{
+									"a": 1,
+									"b": 0,
+									"g": 0,
+									"pos": 0,
+									"r": 0
+								},
+								{
+									"a": 1,
+									"b": 0.472727,
+									"g": 0.472727,
+									"pos": 0.345454,
+									"r": 0.472727
+								},
+								{
+									"a": 1,
+									"b": 0.566168,
+									"g": 0.566168,
+									"pos": 0.690909,
+									"r": 0.566168
+								},
+								{
+									"a": 1,
+									"b": 0.786458,
+									"g": 0.786458,
+									"pos": 1,
+									"r": 0.786458
+								}
+							],
+							"type": "Gradient"
+						}
+					},
+					"type": "colorize"
+				},
+				{
+					"name": "gen_outputs",
+					"node_position": {
+						"x": -55.5,
+						"y": 225
+					},
+					"parameters": {
+
+					},
+					"ports": [
+						{
+							"name": "port0",
+							"type": "rgba"
+						}
+					],
+					"type": "ios"
+				}
+			],
+			"parameters": {
+
+			},
+			"type": "graph"
+		},
+		{
+			"connections": [
+				{
+					"from": "pattern",
+					"from_port": 0,
+					"to": "colorize_2",
+					"to_port": 0
+				},
+				{
+					"from": "colorize_2",
+					"from_port": 0,
+					"to": "colorize_4",
+					"to_port": 0
+				},
+				{
+					"from": "colorize_4",
+					"from_port": 0,
+					"to": "gen_outputs",
+					"to_port": 0
+				}
+			],
+			"label": "Frame",
+			"name": "graph_3",
+			"node_position": {
+				"x": -919.184326,
+				"y": 75.568512
+			},
+			"nodes": [
+				{
+					"name": "colorize_4",
+					"node_position": {
+						"x": -558.307007,
+						"y": 443.205566
+					},
+					"parameters": {
+						"gradient": {
+							"points": [
+								{
+									"a": 1,
+									"b": 0,
+									"g": 0,
+									"pos": 0,
+									"r": 0
+								},
+								{
+									"a": 1,
+									"b": 0.772727,
+									"g": 0.772727,
+									"pos": 0.118182,
+									"r": 0.772727
+								},
+								{
+									"a": 1,
+									"b": 1,
+									"g": 1,
+									"pos": 0.836364,
+									"r": 1
+								},
+								{
+									"a": 1,
+									"b": 1,
+									"g": 1,
+									"pos": 1,
+									"r": 1
+								}
+							],
+							"type": "Gradient"
+						}
+					},
+					"type": "colorize"
+				},
+				{
+					"name": "colorize_2",
+					"node_position": {
+						"x": -559.623047,
+						"y": 376
+					},
+					"parameters": {
+						"gradient": {
+							"points": [
+								{
+									"a": 1,
+									"b": 1,
+									"g": 1,
+									"pos": 0,
+									"r": 1
+								},
+								{
+									"a": 1,
+									"b": 0,
+									"g": 0,
+									"pos": 0.053488,
+									"r": 0
+								}
+							],
+							"type": "Gradient"
+						}
+					},
+					"type": "colorize"
+				},
+				{
+					"name": "pattern",
+					"node_position": {
+						"x": -580.623047,
+						"y": 274.5
+					},
+					"parameters": {
+						"mix": 3,
+						"x_scale": 1,
+						"x_wave": 0,
+						"y_scale": 1,
+						"y_wave": 0
+					},
+					"type": "pattern"
+				},
+				{
+					"name": "gen_outputs",
+					"node_position": {
+						"x": -258.307007,
+						"y": 364.568512
+					},
+					"parameters": {
+
+					},
+					"ports": [
+						{
+							"name": "port0",
+							"type": "rgba"
+						}
+					],
+					"type": "ios"
+				}
+			],
+			"parameters": {
+
+			},
+			"type": "graph"
+		},
+		{
+			"name": "transform",
+			"node_position": {
+				"x": -1138.172852,
+				"y": 24.856049
+			},
+			"parameters": {
+				"repeat": true,
+				"rotate": 0,
+				"scale_x": 0.3,
+				"scale_y": 0.3,
+				"translate_x": 0.15,
+				"translate_y": 0.15
+			},
+			"type": "transform"
+		},
+		{
+			"name": "colorize",
+			"node_position": {
+				"x": -1127.944092,
+				"y": 216.956055
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0,
+							"r": 0
+						},
+						{
+							"a": 1,
+							"b": 0.588542,
+							"g": 0.588542,
+							"pos": 1,
+							"r": 0.588542
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"connections": [
+				{
+					"from": "graph_4",
+					"from_port": 0,
+					"to": "graph",
+					"to_port": 0
+				},
+				{
+					"from": "graph",
+					"from_port": 0,
+					"to": "gen_outputs",
+					"to_port": 0
+				}
+			],
+			"label": "Flower1",
+			"name": "graph_5",
+			"node_position": {
+				"x": -1105.223755,
+				"y": -43.758514
+			},
+			"nodes": [
+				{
+					"connections": [
+						{
+							"from": "pattern",
+							"from_port": 0,
+							"to": "colorize",
+							"to_port": 0
+						},
+						{
+							"from": "colorize",
+							"from_port": 0,
+							"to": "transform",
+							"to_port": 4
+						},
+						{
+							"from": "shape",
+							"from_port": 0,
+							"to": "colorize_2",
+							"to_port": 0
+						},
+						{
+							"from": "colorize_2",
+							"from_port": 0,
+							"to": "transform",
+							"to_port": 0
+						},
+						{
+							"from": "transform",
+							"from_port": 0,
+							"to": "blend",
+							"to_port": 1
+						},
+						{
+							"from": "pattern",
+							"from_port": 0,
+							"to": "colorize_3",
+							"to_port": 0
+						},
+						{
+							"from": "colorize_3",
+							"from_port": 0,
+							"to": "blend",
+							"to_port": 0
+						},
+						{
+							"from": "pattern_2",
+							"from_port": 0,
+							"to": "colorize_4",
+							"to_port": 0
+						},
+						{
+							"from": "blend",
+							"from_port": 0,
+							"to": "blend_2",
+							"to_port": 1
+						},
+						{
+							"from": "blend_2",
+							"from_port": 0,
+							"to": "gen_outputs",
+							"to_port": 0
+						},
+						{
+							"from": "colorize_4",
+							"from_port": 0,
+							"to": "mirror",
+							"to_port": 0
+						},
+						{
+							"from": "mirror",
+							"from_port": 0,
+							"to": "blend_2",
+							"to_port": 0
+						}
+					],
+					"label": "Petal",
+					"name": "graph_4",
+					"node_position": {
+						"x": -861.847046,
+						"y": 454.074829
+					},
+					"nodes": [
+						{
+							"name": "shape",
+							"node_position": {
+								"x": -580.281982,
+								"y": 291.324799
+							},
+							"parameters": {
+								"edge": 1,
+								"radius": 0.845361,
+								"shape": 0,
+								"sides": 6
+							},
+							"type": "shape"
+						},
+						{
+							"name": "pattern",
+							"node_position": {
+								"x": -646.281982,
+								"y": 452.324799
+							},
+							"parameters": {
+								"mix": 0,
+								"x_scale": 1,
+								"x_wave": 4,
+								"y_scale": 1,
+								"y_wave": 3
+							},
+							"type": "pattern"
+						},
+						{
+							"name": "colorize",
+							"node_position": {
+								"x": -603.912109,
+								"y": 551.324829
+							},
+							"parameters": {
+								"gradient": {
+									"points": [
+										{
+											"a": 1,
+											"b": 0.572917,
+											"g": 0.572917,
+											"pos": 0,
+											"r": 0.572917
+										},
+										{
+											"a": 1,
+											"b": 0.848958,
+											"g": 0.848958,
+											"pos": 0.210696,
+											"r": 0.848958
+										},
+										{
+											"a": 1,
+											"b": 0.734375,
+											"g": 0.734375,
+											"pos": 0.677225,
+											"r": 0.734375
+										},
+										{
+											"a": 1,
+											"b": 0.536458,
+											"g": 0.536458,
+											"pos": 1,
+											"r": 0.536458
+										}
+									],
+									"type": "Gradient"
+								}
+							},
+							"type": "colorize"
+						},
+						{
+							"name": "transform",
+							"node_position": {
+								"x": -630.912109,
+								"y": 611.324829
+							},
+							"parameters": {
+								"repeat": false,
+								"rotate": 0,
+								"scale_x": 1,
+								"scale_y": 1,
+								"translate_x": 0,
+								"translate_y": 0
+							},
+							"type": "transform"
+						},
+						{
+							"name": "gen_outputs",
+							"node_position": {
+								"x": 113.718018,
+								"y": 533.074829
+							},
+							"parameters": {
+
+							},
+							"ports": [
+								{
+									"name": "port0",
+									"type": "rgba"
+								}
+							],
+							"type": "ios"
+						},
+						{
+							"name": "colorize_2",
+							"node_position": {
+								"x": -599.834045,
+								"y": 394.574799
+							},
+							"parameters": {
+								"gradient": {
+									"points": [
+										{
+											"a": 1,
+											"b": 0,
+											"g": 0,
+											"pos": 0,
+											"r": 0
+										},
+										{
+											"a": 1,
+											"b": 1,
+											"g": 1,
+											"pos": 0.172727,
+											"r": 1
+										},
+										{
+											"a": 1,
+											"b": 0.755208,
+											"g": 0.755208,
+											"pos": 1,
+											"r": 0.755208
+										}
+									],
+									"type": "Gradient"
+								}
+							},
+							"type": "colorize"
+						},
+						{
+							"name": "blend",
+							"node_position": {
+								"x": -142.870667,
+								"y": 465.158081
+							},
+							"parameters": {
+								"amount": 1,
+								"blend_type": 2
+							},
+							"type": "blend"
+						},
+						{
+							"name": "colorize_3",
+							"node_position": {
+								"x": -346.870667,
+								"y": 413.158081
+							},
+							"parameters": {
+								"gradient": {
+									"points": [
+										{
+											"a": 1,
+											"b": 1,
+											"g": 1,
+											"pos": 0,
+											"r": 1
+										},
+										{
+											"a": 1,
+											"b": 0,
+											"g": 0,
+											"pos": 1,
+											"r": 0
+										}
+									],
+									"type": "Gradient"
+								}
+							},
+							"type": "colorize"
+						},
+						{
+							"name": "pattern_2",
+							"node_position": {
+								"x": -364.870667,
+								"y": 744.158081
+							},
+							"parameters": {
+								"mix": 0,
+								"x_scale": 1,
+								"x_wave": 1,
+								"y_scale": 1,
+								"y_wave": 0
+							},
+							"type": "pattern"
+						},
+						{
+							"name": "colorize_4",
+							"node_position": {
+								"x": -329.870667,
+								"y": 684.158081
+							},
+							"parameters": {
+								"gradient": {
+									"points": [
+										{
+											"a": 1,
+											"b": 1,
+											"g": 1,
+											"pos": 0.636364,
+											"r": 1
+										},
+										{
+											"a": 1,
+											"b": 0.6,
+											"g": 0.6,
+											"pos": 0.936364,
+											"r": 0.6
+										},
+										{
+											"a": 1,
+											"b": 0.296875,
+											"g": 0.296875,
+											"pos": 1,
+											"r": 0.296875
+										}
+									],
+									"type": "Gradient"
+								}
+							},
+							"type": "colorize"
+						},
+						{
+							"name": "blend_2",
+							"node_position": {
+								"x": -141.870667,
+								"y": 561.158081
+							},
+							"parameters": {
+								"amount": 1,
+								"blend_type": 2
+							},
+							"type": "blend"
+						},
+						{
+							"name": "mirror",
+							"node_position": {
+								"x": -316.870667,
+								"y": 611.158081
+							},
+							"parameters": {
+								"direction": 1,
+								"offset": 0.505
+							},
+							"type": "mirror"
+						}
+					],
+					"parameters": {
+
+					},
+					"type": "graph"
+				},
+				{
+					"name": "gen_outputs",
+					"node_position": {
+						"x": -459.912109,
+						"y": 453.241486
+					},
+					"parameters": {
+
+					},
+					"ports": [
+						{
+							"name": "port0",
+							"type": "rgba"
+						}
+					],
+					"type": "ios"
+				},
+				{
+					"connections": [
+						{
+							"from": "gen_inputs",
+							"from_port": 0,
+							"to": "transform_2",
+							"to_port": 0
+						},
+						{
+							"from": "blend",
+							"from_port": 0,
+							"to": "gen_outputs",
+							"to_port": 0
+						},
+						{
+							"from": "shape",
+							"from_port": 0,
+							"to": "colorize",
+							"to_port": 0
+						},
+						{
+							"from": "colorize",
+							"from_port": 0,
+							"to": "blend",
+							"to_port": 0
+						},
+						{
+							"from": "transform_2",
+							"from_port": 0,
+							"to": "kaleidoscope_2",
+							"to_port": 0
+						},
+						{
+							"from": "kaleidoscope_2",
+							"from_port": 0,
+							"to": "blend",
+							"to_port": 1
+						}
+					],
+					"label": "Flower Builder",
+					"name": "graph",
+					"node_position": {
+						"x": -700.567932,
+						"y": 449.269257
+					},
+					"nodes": [
+						{
+							"name": "blend",
+							"node_position": {
+								"x": -369.145874,
+								"y": 397.741486
+							},
+							"parameters": {
+								"amount": 1,
+								"blend_type": 9
+							},
+							"type": "blend"
+						},
+						{
+							"name": "transform_2",
+							"node_position": {
+								"x": -651.912109,
+								"y": 396.324829
+							},
+							"parameters": {
+								"repeat": false,
+								"rotate": 0,
+								"scale_x": 0.5,
+								"scale_y": 0.5,
+								"translate_x": 0,
+								"translate_y": -0.2
+							},
+							"type": "transform"
+						},
+						{
+							"name": "shape",
+							"node_position": {
+								"x": -604.145874,
+								"y": 279.741486
+							},
+							"parameters": {
+								"edge": 1,
+								"radius": 0.264981,
+								"shape": 0,
+								"sides": 6
+							},
+							"type": "shape"
+						},
+						{
+							"name": "colorize",
+							"node_position": {
+								"x": -435.145874,
+								"y": 290.741486
+							},
+							"parameters": {
+								"gradient": {
+									"points": [
+										{
+											"a": 1,
+											"b": 0,
+											"g": 0,
+											"pos": 0,
+											"r": 0
+										},
+										{
+											"a": 1,
+											"b": 0.456684,
+											"g": 0.456684,
+											"pos": 0.2,
+											"r": 0.456684
+										},
+										{
+											"a": 1,
+											"b": 0.602823,
+											"g": 0.602823,
+											"pos": 0.318182,
+											"r": 0.602823
+										},
+										{
+											"a": 1,
+											"b": 0.732,
+											"g": 0.732,
+											"pos": 0.463636,
+											"r": 0.732
+										},
+										{
+											"a": 1,
+											"b": 0.9,
+											"g": 0.9,
+											"pos": 0.681818,
+											"r": 0.9
+										},
+										{
+											"a": 1,
+											"b": 1,
+											"g": 1,
+											"pos": 1,
+											"r": 1
+										}
+									],
+									"type": "Gradient"
+								}
+							},
+							"type": "colorize"
+						},
+						{
+							"name": "gen_parameters",
+							"node_position": {
+								"x": -600.145874,
+								"y": 146.741486
+							},
+							"parameters": {
+								"param0": 7,
+								"param1": 0.264981
+							},
+							"type": "remote",
+							"widgets": [
+								{
+									"label": "Unnamed",
+									"linked_widgets": [
+										{
+											"node": "kaleidoscope_2",
+											"widget": "count"
+										}
+									],
+									"name": "param0",
+									"type": "linked_control"
+								},
+								{
+									"label": "Unnamed",
+									"linked_widgets": [
+										{
+											"node": "shape",
+											"widget": "radius"
+										}
+									],
+									"name": "param1",
+									"type": "linked_control"
+								}
+							]
+						},
+						{
+							"name": "gen_inputs",
+							"node_position": {
+								"x": -951.912109,
+								"y": 356.269257
+							},
+							"parameters": {
+
+							},
+							"ports": [
+								{
+									"name": "port0",
+									"type": "rgba"
+								}
+							],
+							"type": "ios"
+						},
+						{
+							"name": "gen_outputs",
+							"node_position": {
+								"x": -69.145874,
+								"y": 356.269257
+							},
+							"parameters": {
+
+							},
+							"ports": [
+								{
+									"name": "port0",
+									"type": "rgba"
+								}
+							],
+							"type": "ios"
+						},
+						{
+							"name": "kaleidoscope_2",
+							"node_position": {
+								"x": -615.808228,
+								"y": 593.956787
+							},
+							"parameters": {
+								"count": 7,
+								"direction": 0,
+								"offset": 0
+							},
+							"type": "kaleidoscope"
+						}
+					],
+					"parameters": {
+						"param0": 7,
+						"param1": 0.264981
+					},
+					"type": "graph"
+				}
+			],
+			"parameters": {
+
+			},
+			"type": "graph"
+		},
+		{
+			"name": "transform_2",
+			"node_position": {
+				"x": -1063.855835,
+				"y": 370.619873
+			},
+			"parameters": {
+				"repeat": false,
+				"rotate": 0,
+				"scale_x": 0.4,
+				"scale_y": 0.4,
+				"translate_x": 0,
+				"translate_y": 0
+			},
+			"type": "transform"
+		},
+		{
+			"name": "transform_2_2",
+			"node_position": {
+				"x": -832.475098,
+				"y": 370.055542
+			},
+			"parameters": {
+				"repeat": true,
+				"rotate": 0,
+				"scale_x": 0.3,
+				"scale_y": 0.3,
+				"translate_x": 0,
+				"translate_y": 0
+			},
+			"type": "transform"
+		},
+		{
+			"connections": [
+				{
+					"from": "graph_4",
+					"from_port": 0,
+					"to": "graph_6",
+					"to_port": 0
+				},
+				{
+					"from": "graph_6",
+					"from_port": 0,
+					"to": "gen_outputs",
+					"to_port": 0
+				}
+			],
+			"label": "Flower2",
+			"name": "graph_7",
+			"node_position": {
+				"x": -952.17395,
+				"y": 292.142639
+			},
+			"nodes": [
+				{
+					"connections": [
+						{
+							"from": "pattern",
+							"from_port": 0,
+							"to": "colorize",
+							"to_port": 0
+						},
+						{
+							"from": "colorize",
+							"from_port": 0,
+							"to": "transform",
+							"to_port": 4
+						},
+						{
+							"from": "shape",
+							"from_port": 0,
+							"to": "colorize_2",
+							"to_port": 0
+						},
+						{
+							"from": "colorize_2",
+							"from_port": 0,
+							"to": "transform",
+							"to_port": 0
+						},
+						{
+							"from": "transform",
+							"from_port": 0,
+							"to": "blend",
+							"to_port": 1
+						},
+						{
+							"from": "pattern",
+							"from_port": 0,
+							"to": "colorize_3",
+							"to_port": 0
+						},
+						{
+							"from": "colorize_3",
+							"from_port": 0,
+							"to": "blend",
+							"to_port": 0
+						},
+						{
+							"from": "pattern_2",
+							"from_port": 0,
+							"to": "colorize_4",
+							"to_port": 0
+						},
+						{
+							"from": "blend",
+							"from_port": 0,
+							"to": "blend_2",
+							"to_port": 1
+						},
+						{
+							"from": "blend_2",
+							"from_port": 0,
+							"to": "gen_outputs",
+							"to_port": 0
+						},
+						{
+							"from": "colorize_4",
+							"from_port": 0,
+							"to": "mirror",
+							"to_port": 0
+						},
+						{
+							"from": "mirror",
+							"from_port": 0,
+							"to": "blend_2",
+							"to_port": 0
+						}
+					],
+					"label": "Petal",
+					"name": "graph_4",
+					"node_position": {
+						"x": -635.313538,
+						"y": 599.04541
+					},
+					"nodes": [
+						{
+							"name": "shape",
+							"node_position": {
+								"x": -552.281982,
+								"y": 258.324799
+							},
+							"parameters": {
+								"edge": 1,
+								"radius": 0.845361,
+								"shape": 0,
+								"sides": 6
+							},
+							"type": "shape"
+						},
+						{
+							"name": "pattern",
+							"node_position": {
+								"x": -618.281982,
+								"y": 419.324799
+							},
+							"parameters": {
+								"mix": 0,
+								"x_scale": 1,
+								"x_wave": 4,
+								"y_scale": 1,
+								"y_wave": 3
+							},
+							"type": "pattern"
+						},
+						{
+							"name": "colorize",
+							"node_position": {
+								"x": -575.912109,
+								"y": 518.324829
+							},
+							"parameters": {
+								"gradient": {
+									"points": [
+										{
+											"a": 1,
+											"b": 0.572917,
+											"g": 0.572917,
+											"pos": 0,
+											"r": 0.572917
+										},
+										{
+											"a": 1,
+											"b": 0.876823,
+											"g": 0.876823,
+											"pos": 0.092589,
+											"r": 0.876823
+										},
+										{
+											"a": 1,
+											"b": 1,
+											"g": 1,
+											"pos": 0.283423,
+											"r": 1
+										},
+										{
+											"a": 1,
+											"b": 0.776042,
+											"g": 0.776042,
+											"pos": 0.677225,
+											"r": 0.776042
+										},
+										{
+											"a": 1,
+											"b": 0.536458,
+											"g": 0.536458,
+											"pos": 1,
+											"r": 0.536458
+										}
+									],
+									"type": "Gradient"
+								}
+							},
+							"type": "colorize"
+						},
+						{
+							"name": "transform",
+							"node_position": {
+								"x": -602.912109,
+								"y": 578.324829
+							},
+							"parameters": {
+								"repeat": false,
+								"rotate": 0,
+								"scale_x": 1,
+								"scale_y": 1,
+								"translate_x": 0,
+								"translate_y": 0
+							},
+							"type": "transform"
+						},
+						{
+							"name": "gen_outputs",
+							"node_position": {
+								"x": 154.718018,
+								"y": 556.074829
+							},
+							"parameters": {
+
+							},
+							"ports": [
+								{
+									"name": "port0",
+									"type": "rgba"
+								}
+							],
+							"type": "ios"
+						},
+						{
+							"name": "colorize_2",
+							"node_position": {
+								"x": -571.834045,
+								"y": 361.574799
+							},
+							"parameters": {
+								"gradient": {
+									"points": [
+										{
+											"a": 1,
+											"b": 0,
+											"g": 0,
+											"pos": 0,
+											"r": 0
+										},
+										{
+											"a": 1,
+											"b": 1,
+											"g": 1,
+											"pos": 0.172727,
+											"r": 1
+										},
+										{
+											"a": 1,
+											"b": 0.755208,
+											"g": 0.755208,
+											"pos": 1,
+											"r": 0.755208
+										}
+									],
+									"type": "Gradient"
+								}
+							},
+							"type": "colorize"
+						},
+						{
+							"name": "blend",
+							"node_position": {
+								"x": -118.870667,
+								"y": 440.158081
+							},
+							"parameters": {
+								"amount": 1,
+								"blend_type": 2
+							},
+							"type": "blend"
+						},
+						{
+							"name": "colorize_3",
+							"node_position": {
+								"x": -346.870667,
+								"y": 413.158081
+							},
+							"parameters": {
+								"gradient": {
+									"points": [
+										{
+											"a": 1,
+											"b": 1,
+											"g": 1,
+											"pos": 0,
+											"r": 1
+										},
+										{
+											"a": 1,
+											"b": 0,
+											"g": 0,
+											"pos": 1,
+											"r": 0
+										}
+									],
+									"type": "Gradient"
+								}
+							},
+							"type": "colorize"
+						},
+						{
+							"name": "pattern_2",
+							"node_position": {
+								"x": -380.870667,
+								"y": 786.158081
+							},
+							"parameters": {
+								"mix": 0,
+								"x_scale": 1,
+								"x_wave": 1,
+								"y_scale": 1,
+								"y_wave": 0
+							},
+							"type": "pattern"
+						},
+						{
+							"name": "colorize_4",
+							"node_position": {
+								"x": -332.870667,
+								"y": 723.158081
+							},
+							"parameters": {
+								"gradient": {
+									"points": [
+										{
+											"a": 1,
+											"b": 1,
+											"g": 1,
+											"pos": 0.636364,
+											"r": 1
+										},
+										{
+											"a": 1,
+											"b": 0.6,
+											"g": 0.6,
+											"pos": 0.936364,
+											"r": 0.6
+										},
+										{
+											"a": 1,
+											"b": 0.296875,
+											"g": 0.296875,
+											"pos": 1,
+											"r": 0.296875
+										}
+									],
+									"type": "Gradient"
+								}
+							},
+							"type": "colorize"
+						},
+						{
+							"name": "blend_2",
+							"node_position": {
+								"x": -117.870667,
+								"y": 536.158081
+							},
+							"parameters": {
+								"amount": 1,
+								"blend_type": 2
+							},
+							"type": "blend"
+						},
+						{
+							"name": "mirror",
+							"node_position": {
+								"x": -330.870667,
+								"y": 635.158081
+							},
+							"parameters": {
+								"direction": 1,
+								"offset": 0.505
+							},
+							"type": "mirror"
+						}
+					],
+					"parameters": {
+
+					},
+					"type": "graph"
+				},
+				{
+					"connections": [
+						{
+							"from": "gen_inputs",
+							"from_port": 0,
+							"to": "transform_2",
+							"to_port": 0
+						},
+						{
+							"from": "blend",
+							"from_port": 0,
+							"to": "gen_outputs",
+							"to_port": 0
+						},
+						{
+							"from": "shape",
+							"from_port": 0,
+							"to": "colorize",
+							"to_port": 0
+						},
+						{
+							"from": "colorize",
+							"from_port": 0,
+							"to": "blend",
+							"to_port": 0
+						},
+						{
+							"from": "transform_2",
+							"from_port": 0,
+							"to": "kaleidoscope",
+							"to_port": 0
+						},
+						{
+							"from": "kaleidoscope",
+							"from_port": 0,
+							"to": "blend",
+							"to_port": 1
+						}
+					],
+					"label": "Flower Builder",
+					"name": "graph_6",
+					"node_position": {
+						"x": -477.034424,
+						"y": 593.239868
+					},
+					"nodes": [
+						{
+							"name": "blend",
+							"node_position": {
+								"x": -369.145874,
+								"y": 397.741486
+							},
+							"parameters": {
+								"amount": 1,
+								"blend_type": 9
+							},
+							"type": "blend"
+						},
+						{
+							"name": "transform_2",
+							"node_position": {
+								"x": -651.912109,
+								"y": 396.324829
+							},
+							"parameters": {
+								"repeat": false,
+								"rotate": 0,
+								"scale_x": 0.5,
+								"scale_y": 0.5,
+								"translate_x": 0,
+								"translate_y": -0.2
+							},
+							"type": "transform"
+						},
+						{
+							"name": "shape",
+							"node_position": {
+								"x": -604.145874,
+								"y": 279.741486
+							},
+							"parameters": {
+								"edge": 1,
+								"radius": 0.330915,
+								"shape": 0,
+								"sides": 6
+							},
+							"type": "shape"
+						},
+						{
+							"name": "colorize",
+							"node_position": {
+								"x": -435.145874,
+								"y": 290.741486
+							},
+							"parameters": {
+								"gradient": {
+									"points": [
+										{
+											"a": 1,
+											"b": 0,
+											"g": 0,
+											"pos": 0,
+											"r": 0
+										},
+										{
+											"a": 1,
+											"b": 0.456684,
+											"g": 0.456684,
+											"pos": 0.2,
+											"r": 0.456684
+										},
+										{
+											"a": 1,
+											"b": 0.602823,
+											"g": 0.602823,
+											"pos": 0.318182,
+											"r": 0.602823
+										},
+										{
+											"a": 1,
+											"b": 0.732,
+											"g": 0.732,
+											"pos": 0.463636,
+											"r": 0.732
+										},
+										{
+											"a": 1,
+											"b": 0.9,
+											"g": 0.9,
+											"pos": 0.681818,
+											"r": 0.9
+										},
+										{
+											"a": 1,
+											"b": 1,
+											"g": 1,
+											"pos": 1,
+											"r": 1
+										}
+									],
+									"type": "Gradient"
+								}
+							},
+							"type": "colorize"
+						},
+						{
+							"name": "gen_parameters",
+							"node_position": {
+								"x": -650.145874,
+								"y": 158.741486
+							},
+							"parameters": {
+								"param0": 4,
+								"param1": 0.330915
+							},
+							"type": "remote",
+							"widgets": [
+								{
+									"label": "Unnamed",
+									"linked_widgets": [
+										{
+											"node": "kaleidoscope",
+											"widget": "count"
+										}
+									],
+									"name": "param0",
+									"type": "linked_control"
+								},
+								{
+									"label": "Unnamed",
+									"linked_widgets": [
+										{
+											"node": "shape",
+											"widget": "radius"
+										}
+									],
+									"name": "param1",
+									"type": "linked_control"
+								}
+							]
+						},
+						{
+							"name": "gen_inputs",
+							"node_position": {
+								"x": -951.912109,
+								"y": 356.269257
+							},
+							"parameters": {
+
+							},
+							"ports": [
+								{
+									"name": "port0",
+									"type": "rgba"
+								}
+							],
+							"type": "ios"
+						},
+						{
+							"name": "gen_outputs",
+							"node_position": {
+								"x": -69.145874,
+								"y": 356.269257
+							},
+							"parameters": {
+
+							},
+							"ports": [
+								{
+									"name": "port0",
+									"type": "rgba"
+								}
+							],
+							"type": "ios"
+						},
+						{
+							"name": "kaleidoscope",
+							"node_position": {
+								"x": -612.808228,
+								"y": 591.706787
+							},
+							"parameters": {
+								"count": 4,
+								"direction": 0,
+								"offset": 0
+							},
+							"type": "kaleidoscope"
+						}
+					],
+					"parameters": {
+						"param0": 4,
+						"param1": 0.330915
+					},
+					"type": "graph"
+				},
+				{
+					"name": "gen_outputs",
+					"node_position": {
+						"x": -177.034424,
+						"y": 596.142639
+					},
+					"parameters": {
+
+					},
+					"ports": [
+						{
+							"name": "port0",
+							"type": "rgba"
+						}
+					],
+					"type": "ios"
+				}
+			],
+			"parameters": {
+
+			},
+			"type": "graph"
+		},
+		{
+			"connections": [
+				{
+					"from": "gen_inputs",
+					"from_port": 0,
+					"to": "blend",
+					"to_port": 0
+				},
+				{
+					"from": "gen_inputs",
+					"from_port": 1,
+					"to": "blend",
+					"to_port": 1
+				},
+				{
+					"from": "gen_inputs",
+					"from_port": 2,
+					"to": "blend_2",
+					"to_port": 0
+				},
+				{
+					"from": "blend_2",
+					"from_port": 0,
+					"to": "blend_3",
+					"to_port": 1
+				},
+				{
+					"from": "blend_3",
+					"from_port": 0,
+					"to": "gen_outputs",
+					"to_port": 0
+				},
+				{
+					"from": "blend",
+					"from_port": 0,
+					"to": "blend_2",
+					"to_port": 1
+				},
+				{
+					"from": "gen_inputs",
+					"from_port": 3,
+					"to": "blend_3",
+					"to_port": 0
+				}
+			],
+			"label": "Lighten4",
+			"name": "graph_4",
+			"node_position": {
+				"x": -769.075928,
+				"y": 86.158661
+			},
+			"nodes": [
+				{
+					"name": "blend_2",
+					"node_position": {
+						"x": 14.684723,
+						"y": 336.856049
+					},
+					"parameters": {
+						"amount": 1,
+						"blend_type": 9
+					},
+					"type": "blend"
+				},
+				{
+					"name": "blend",
+					"node_position": {
+						"x": 14.376953,
+						"y": 246.5
+					},
+					"parameters": {
+						"amount": 1,
+						"blend_type": 9
+					},
+					"type": "blend"
+				},
+				{
+					"name": "blend_3",
+					"node_position": {
+						"x": 14.710419,
+						"y": 426.119873
+					},
+					"parameters": {
+						"amount": 1,
+						"blend_type": 9
+					},
+					"type": "blend"
+				},
+				{
+					"name": "gen_inputs",
+					"node_position": {
+						"x": -227.623047,
+						"y": 380.158661
+					},
+					"parameters": {
+
+					},
+					"ports": [
+						{
+							"name": "port0",
+							"type": "rgba"
+						},
+						{
+							"name": "port1",
+							"type": "rgba"
+						},
+						{
+							"name": "port2",
+							"type": "rgba"
+						},
+						{
+							"name": "port3",
+							"type": "rgba"
+						}
+					],
+					"type": "ios"
+				},
+				{
+					"name": "gen_outputs",
+					"node_position": {
+						"x": 367.684723,
+						"y": 417.158661
+					},
+					"parameters": {
+
+					},
+					"ports": [
+						{
+							"name": "port0",
+							"type": "rgba"
+						}
+					],
+					"type": "ios"
+				}
+			],
+			"parameters": {
+
+			},
+			"type": "graph"
+		},
+		{
+			"name": "colorize_2",
+			"node_position": {
+				"x": -819.609863,
+				"y": 296.695862
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0,
+							"r": 0
+						},
+						{
+							"a": 1,
+							"b": 0.630208,
+							"g": 0.630208,
+							"pos": 1,
+							"r": 0.630208
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "perlin",
+			"node_position": {
+				"x": -730.287415,
+				"y": -51.888901
+			},
+			"parameters": {
+				"iterations": 7,
+				"persistence": 0.5,
+				"scale_x": 16,
+				"scale_y": 16
+			},
+			"type": "perlin"
+		},
+		{
+			"name": "colorize_3",
+			"node_position": {
+				"x": -494.287415,
+				"y": -28.888901
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0.666667,
+							"g": 0.666667,
+							"pos": 0,
+							"r": 0.666667
+						},
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 1,
+							"r": 1
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "transform_3",
+			"node_position": {
+				"x": -1369.070557,
+				"y": 25.255157
+			},
+			"parameters": {
+				"repeat": false,
+				"rotate": 0,
+				"scale_x": 1.15,
+				"scale_y": 1.15,
+				"translate_x": 0,
+				"translate_y": 0
+			},
+			"type": "transform"
+		}
+	],
+	"parameters": {
+
+	},
+	"type": "graph"
+}

--- a/addons/material_maker/examples/mandelbrot.ptex
+++ b/addons/material_maker/examples/mandelbrot.ptex
@@ -1,1 +1,173 @@
-{"connections":[{"from":"custom_0","from_port":0,"to":"colorize_0","to_port":0},{"from":"colorize_0","from_port":0,"to":"Material","to_port":3}],"label":"Graph","name":"362","node_position":{"x":0,"y":0},"nodes":[{"name":"Material","node_position":{"x":200,"y":0},"parameters":{"albedo_color":{"a":1,"b":0,"g":0,"r":0,"type":"Color"},"ao_light_affect":1,"depth_scale":1,"emission_energy":1,"metallic":1,"normal_scale":1,"resolution":1,"roughness":1,"size":11},"type":"material"},{"name":"custom_0","node_position":{"x":-211,"y":208},"parameters":{"contrast":10,"scale":1,"x":0,"y":0},"shader_model":{"global":"float mandelbrot(vec2 uv) {\n    float di =  1.0;\n    vec2 z  = vec2(0.0);\n    float m2 = 0.0;\n    vec2 dz = vec2(0.0);\n    for( int i=0; i<200; i++ )\n    {\n        if (m2>1024.0 ) {\n\t\t\tdi=0.0;\n\t\t\tbreak;\n\t\t}\n\n\t\t// Z' -> 2·Z·Z' + 1\n        dz = 2.0*vec2(z.x*dz.x-z.y*dz.y, z.x*dz.y + z.y*dz.x) + vec2(1.0,0.0);\n\t\t\t\n        // Z -> Z² + c\t\t\t\n        z = vec2( z.x*z.x - z.y*z.y, 2.0*z.x*z.y ) + uv;\n\t\t\t\n        m2 = dot(z,z);\n    }\n\n    // distance\t\n\t// d(c) = |Z|·log|Z|/|Z'|\n\tfloat d = 0.5*sqrt(dot(z,z)/dot(dz,dz))*log(dot(z,z));\n    if( di>0.5 ) d=0.0;\n\treturn d;\n}","instance":"float $(name)_xyz(vec2 uv) {\n\treturn mandelbrot(uv);\n}","name":"Mandelbrot","outputs":[{"f":"clamp($(name)_xyz(vec2($(x), $(y))+$(scale)*(2.0*$(uv)-1.0))*$(contrast), 0.0, 1.0)","type":"f"}],"parameters":[{"label":"Scale","max":3,"min":0,"name":"scale","step":0.0001,"type":"float","widget":"spinbox"},{"label":"X","max":2,"min":-2,"name":"x","step":0.0001,"type":"float","widget":"spinbox"},{"label":"Y","max":2,"min":-2,"name":"y","step":0.0001,"type":"float","widget":"spinbox"},{"label":"Contrast","max":10000,"min":1,"name":"contrast","step":0.0001,"type":"float","widget":"spinbox"}]},"type":"shader"},{"name":"colorize_0","node_position":{"x":-99.75,"y":-7.25},"parameters":{"gradient":{"points":[{"a":1,"b":0,"g":0,"pos":0,"r":1},{"a":1,"b":0,"g":0.96875,"pos":0.2,"r":1},{"a":1,"b":0.0625,"g":1,"pos":0.4,"r":0},{"a":1,"b":1,"g":1,"pos":0.618182,"r":0},{"a":1,"b":0.965909,"g":0,"pos":0.818182,"r":0},{"a":1,"b":1,"g":0,"pos":1,"r":0.9375}],"type":"Gradient"}},"type":"colorize"}],"parameters":{},"type":"graph"}
+{
+	"connections": [
+		{
+			"from": "custom_0",
+			"from_port": 0,
+			"to": "colorize_0",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_0",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 3
+		}
+	],
+	"label": "Graph",
+	"name": "362",
+	"node_position": {
+		"x": 0,
+		"y": 0
+	},
+	"nodes": [
+		{
+			"name": "Material",
+			"node_position": {
+				"x": 200,
+				"y": 0
+			},
+			"parameters": {
+				"albedo_color": {
+					"a": 1,
+					"b": 0,
+					"g": 0,
+					"r": 0,
+					"type": "Color"
+				},
+				"ao_light_affect": 1,
+				"depth_scale": 1,
+				"emission_energy": 1,
+				"metallic": 1,
+				"normal_scale": 1,
+				"resolution": 1,
+				"roughness": 1,
+				"size": 11
+			},
+			"type": "material"
+		},
+		{
+			"name": "custom_0",
+			"node_position": {
+				"x": -211,
+				"y": 208
+			},
+			"parameters": {
+				"contrast": 10,
+				"scale": 1,
+				"x": 0,
+				"y": 0
+			},
+			"shader_model": {
+				"global": "float mandelbrot(vec2 uv) {\n    float di =  1.0;\n    vec2 z  = vec2(0.0);\n    float m2 = 0.0;\n    vec2 dz = vec2(0.0);\n    for( int i=0; i<200; i++ )\n    {\n        if (m2>1024.0 ) {\n\t\t\tdi=0.0;\n\t\t\tbreak;\n\t\t}\n\n\t\t// Z' -> 2·Z·Z' + 1\n        dz = 2.0*vec2(z.x*dz.x-z.y*dz.y, z.x*dz.y + z.y*dz.x) + vec2(1.0,0.0);\n\t\t\t\n        // Z -> Z² + c\t\t\t\n        z = vec2( z.x*z.x - z.y*z.y, 2.0*z.x*z.y ) + uv;\n\t\t\t\n        m2 = dot(z,z);\n    }\n\n    // distance\t\n\t// d(c) = |Z|·log|Z|/|Z'|\n\tfloat d = 0.5*sqrt(dot(z,z)/dot(dz,dz))*log(dot(z,z));\n    if( di>0.5 ) d=0.0;\n\treturn d;\n}",
+				"instance": "float $(name)_xyz(vec2 uv) {\n\treturn mandelbrot(uv);\n}",
+				"name": "Mandelbrot",
+				"outputs": [
+					{
+						"f": "clamp($(name)_xyz(vec2($(x), $(y))+$(scale)*(2.0*$(uv)-1.0))*$(contrast), 0.0, 1.0)",
+						"type": "f"
+					}
+				],
+				"parameters": [
+					{
+						"label": "Scale",
+						"max": 3,
+						"min": 0,
+						"name": "scale",
+						"step": 0.0001,
+						"type": "float",
+						"widget": "spinbox"
+					},
+					{
+						"label": "X",
+						"max": 2,
+						"min": -2,
+						"name": "x",
+						"step": 0.0001,
+						"type": "float",
+						"widget": "spinbox"
+					},
+					{
+						"label": "Y",
+						"max": 2,
+						"min": -2,
+						"name": "y",
+						"step": 0.0001,
+						"type": "float",
+						"widget": "spinbox"
+					},
+					{
+						"label": "Contrast",
+						"max": 10000,
+						"min": 1,
+						"name": "contrast",
+						"step": 0.0001,
+						"type": "float",
+						"widget": "spinbox"
+					}
+				]
+			},
+			"type": "shader"
+		},
+		{
+			"name": "colorize_0",
+			"node_position": {
+				"x": -99.75,
+				"y": -7.25
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0,
+							"r": 1
+						},
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0.96875,
+							"pos": 0.2,
+							"r": 1
+						},
+						{
+							"a": 1,
+							"b": 0.0625,
+							"g": 1,
+							"pos": 0.4,
+							"r": 0
+						},
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0.618182,
+							"r": 0
+						},
+						{
+							"a": 1,
+							"b": 0.965909,
+							"g": 0,
+							"pos": 0.818182,
+							"r": 0
+						},
+						{
+							"a": 1,
+							"b": 1,
+							"g": 0,
+							"pos": 1,
+							"r": 0.9375
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		}
+	],
+	"parameters": {
+
+	},
+	"type": "graph"
+}

--- a/addons/material_maker/examples/marble.ptex
+++ b/addons/material_maker/examples/marble.ptex
@@ -1,1 +1,504 @@
-{"connections":[{"from":"perlin_0","from_port":0,"to":"warp_0","to_port":1},{"from":"warp_0","from_port":0,"to":"colorize_0","to_port":0},{"from":"pattern_1","from_port":0,"to":"warp_1","to_port":0},{"from":"perlin_0","from_port":0,"to":"warp_1","to_port":1},{"from":"warp_1","from_port":0,"to":"colorize_1","to_port":0},{"from":"colorize_0","from_port":0,"to":"blend_0","to_port":0},{"from":"colorize_1","from_port":0,"to":"blend_0","to_port":1},{"from":"blend_0","from_port":0,"to":"colorize_2","to_port":0},{"from":"colorize_2","from_port":0,"to":"Material","to_port":0},{"from":"colorize_3","from_port":0,"to":"Material","to_port":2},{"from":"uniform_0","from_port":0,"to":"Material","to_port":1},{"from":"blend_1","from_port":0,"to":"colorize_3","to_port":0},{"from":"blend_0","from_port":0,"to":"blend_1","to_port":1},{"from":"perlin_1","from_port":0,"to":"colorize_4","to_port":0},{"from":"colorize_4","from_port":0,"to":"blend_1","to_port":0},{"from":"voronoi_0","from_port":0,"to":"warp_0","to_port":0}],"label":"Graph","name":"297","node_position":{"x":0,"y":0},"nodes":[{"name":"pattern_1","node_position":{"x":15,"y":492},"parameters":{"mix":0,"x_scale":8,"x_wave":0,"y_scale":0,"y_wave":4},"type":"pattern"},{"name":"colorize_1","node_position":{"x":349,"y":386},"parameters":{"gradient":{"points":[{"a":1,"b":1,"g":1,"pos":0.035714,"r":1},{"a":1,"b":0,"g":0,"pos":0.142857,"r":0},{"a":1,"b":1,"g":1,"pos":0.258929,"r":1},{"a":1,"b":0,"g":0,"pos":0.535714,"r":0},{"a":1,"b":1,"g":1,"pos":0.723214,"r":1},{"a":1,"b":0,"g":0,"pos":0.848214,"r":0},{"a":1,"b":1,"g":1,"pos":0.982143,"r":1}],"type":"Gradient"}},"type":"colorize"},{"name":"warp_1","node_position":{"x":257,"y":418},"parameters":{"amount":1,"eps":0.045,"epsilon":0},"type":"warp"},{"name":"uniform_0","node_position":{"x":484,"y":126},"parameters":{"color":{"a":1,"b":0,"g":0,"r":0,"type":"Color"}},"type":"uniform"},{"name":"blend_1","node_position":{"x":249,"y":45},"parameters":{"amount":0.9,"blend_type":0},"type":"blend"},{"name":"Material","node_position":{"x":676,"y":101},"parameters":{"albedo_color":{"a":1,"b":1,"g":1,"r":1,"type":"Color"},"ao_light_affect":1,"depth_scale":1,"emission_energy":1,"metallic":1,"normal_scale":1,"resolution":1,"roughness":1,"size":11},"type":"material"},{"name":"voronoi_0","node_position":{"x":8,"y":178},"parameters":{"intensity":1,"randomness":1,"scale_x":8,"scale_y":4},"type":"voronoi"},{"name":"colorize_0","node_position":{"x":349,"y":309},"parameters":{"gradient":{"points":[{"a":1,"b":1,"g":1,"pos":0.017857,"r":1},{"a":1,"b":0,"g":0,"pos":0.125,"r":0},{"a":1,"b":1,"g":1,"pos":0.241071,"r":1},{"a":1,"b":1,"g":1,"pos":0.455357,"r":1},{"a":1,"b":0,"g":0,"pos":0.616071,"r":0},{"a":1,"b":1,"g":1,"pos":0.723214,"r":1},{"a":1,"b":1,"g":1,"pos":0.857143,"r":1},{"a":1,"b":0,"g":0,"pos":0.946429,"r":0},{"a":1,"b":1,"g":1,"pos":0.982143,"r":1}],"type":"Gradient"}},"type":"colorize"},{"name":"perlin_1","node_position":{"x":-264,"y":25},"parameters":{"iterations":6,"persistence":1,"scale_x":8,"scale_y":8},"type":"perlin"},{"name":"colorize_4","node_position":{"x":24,"y":81},"parameters":{"gradient":{"points":[{"a":1,"b":0,"g":0,"pos":0.190909,"r":0},{"a":1,"b":1,"g":1,"pos":0.463636,"r":1}],"type":"Gradient"}},"type":"colorize"},{"name":"perlin_0","node_position":{"x":15,"y":328},"parameters":{"iterations":4,"persistence":0.5,"scale_x":4,"scale_y":4},"type":"perlin"},{"name":"warp_0","node_position":{"x":246,"y":306},"parameters":{"amount":0.8,"eps":0.045,"epsilon":0},"type":"warp"},{"name":"colorize_3","node_position":{"x":272,"y":171},"parameters":{"gradient":{"points":[{"a":1,"b":0.484375,"g":0.484375,"pos":0,"r":1},{"a":1,"b":0.744792,"g":0.744792,"pos":0.390909,"r":0.744792},{"a":1,"b":0.4375,"g":0.4375,"pos":1,"r":0.4375}],"type":"Gradient"}},"type":"colorize"},{"name":"blend_0","node_position":{"x":544,"y":339},"parameters":{"amount":0.65,"blend_type":0},"type":"blend"},{"name":"colorize_2","node_position":{"x":765,"y":404},"parameters":{"gradient":{"points":[{"a":1,"b":0.791667,"g":0.908854,"pos":0,"r":1},{"a":1,"b":0.84375,"g":0.931641,"pos":0.236364,"r":1},{"a":1,"b":1,"g":1,"pos":1,"r":1}],"type":"Gradient"}},"type":"colorize"}],"parameters":{},"type":"graph"}
+{
+	"connections": [
+		{
+			"from": "perlin_0",
+			"from_port": 0,
+			"to": "warp_0",
+			"to_port": 1
+		},
+		{
+			"from": "warp_0",
+			"from_port": 0,
+			"to": "colorize_0",
+			"to_port": 0
+		},
+		{
+			"from": "pattern_1",
+			"from_port": 0,
+			"to": "warp_1",
+			"to_port": 0
+		},
+		{
+			"from": "perlin_0",
+			"from_port": 0,
+			"to": "warp_1",
+			"to_port": 1
+		},
+		{
+			"from": "warp_1",
+			"from_port": 0,
+			"to": "colorize_1",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_0",
+			"from_port": 0,
+			"to": "blend_0",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_1",
+			"from_port": 0,
+			"to": "blend_0",
+			"to_port": 1
+		},
+		{
+			"from": "blend_0",
+			"from_port": 0,
+			"to": "colorize_2",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_2",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_3",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 2
+		},
+		{
+			"from": "uniform_0",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 1
+		},
+		{
+			"from": "blend_1",
+			"from_port": 0,
+			"to": "colorize_3",
+			"to_port": 0
+		},
+		{
+			"from": "blend_0",
+			"from_port": 0,
+			"to": "blend_1",
+			"to_port": 1
+		},
+		{
+			"from": "perlin_1",
+			"from_port": 0,
+			"to": "colorize_4",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_4",
+			"from_port": 0,
+			"to": "blend_1",
+			"to_port": 0
+		},
+		{
+			"from": "voronoi_0",
+			"from_port": 0,
+			"to": "warp_0",
+			"to_port": 0
+		}
+	],
+	"label": "Graph",
+	"name": "297",
+	"node_position": {
+		"x": 0,
+		"y": 0
+	},
+	"nodes": [
+		{
+			"name": "pattern_1",
+			"node_position": {
+				"x": 15,
+				"y": 492
+			},
+			"parameters": {
+				"mix": 0,
+				"x_scale": 8,
+				"x_wave": 0,
+				"y_scale": 0,
+				"y_wave": 4
+			},
+			"type": "pattern"
+		},
+		{
+			"name": "colorize_1",
+			"node_position": {
+				"x": 349,
+				"y": 386
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0.035714,
+							"r": 1
+						},
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0.142857,
+							"r": 0
+						},
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0.258929,
+							"r": 1
+						},
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0.535714,
+							"r": 0
+						},
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0.723214,
+							"r": 1
+						},
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0.848214,
+							"r": 0
+						},
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0.982143,
+							"r": 1
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "warp_1",
+			"node_position": {
+				"x": 257,
+				"y": 418
+			},
+			"parameters": {
+				"amount": 1,
+				"eps": 0.045,
+				"epsilon": 0
+			},
+			"type": "warp"
+		},
+		{
+			"name": "uniform_0",
+			"node_position": {
+				"x": 484,
+				"y": 126
+			},
+			"parameters": {
+				"color": {
+					"a": 1,
+					"b": 0,
+					"g": 0,
+					"r": 0,
+					"type": "Color"
+				}
+			},
+			"type": "uniform"
+		},
+		{
+			"name": "blend_1",
+			"node_position": {
+				"x": 249,
+				"y": 45
+			},
+			"parameters": {
+				"amount": 0.9,
+				"blend_type": 0
+			},
+			"type": "blend"
+		},
+		{
+			"name": "Material",
+			"node_position": {
+				"x": 676,
+				"y": 101
+			},
+			"parameters": {
+				"albedo_color": {
+					"a": 1,
+					"b": 1,
+					"g": 1,
+					"r": 1,
+					"type": "Color"
+				},
+				"ao_light_affect": 1,
+				"depth_scale": 1,
+				"emission_energy": 1,
+				"metallic": 1,
+				"normal_scale": 1,
+				"resolution": 1,
+				"roughness": 1,
+				"size": 11
+			},
+			"type": "material"
+		},
+		{
+			"name": "voronoi_0",
+			"node_position": {
+				"x": 8,
+				"y": 178
+			},
+			"parameters": {
+				"intensity": 1,
+				"randomness": 1,
+				"scale_x": 8,
+				"scale_y": 4
+			},
+			"type": "voronoi"
+		},
+		{
+			"name": "colorize_0",
+			"node_position": {
+				"x": 349,
+				"y": 309
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0.017857,
+							"r": 1
+						},
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0.125,
+							"r": 0
+						},
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0.241071,
+							"r": 1
+						},
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0.455357,
+							"r": 1
+						},
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0.616071,
+							"r": 0
+						},
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0.723214,
+							"r": 1
+						},
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0.857143,
+							"r": 1
+						},
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0.946429,
+							"r": 0
+						},
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0.982143,
+							"r": 1
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "perlin_1",
+			"node_position": {
+				"x": -264,
+				"y": 25
+			},
+			"parameters": {
+				"iterations": 6,
+				"persistence": 1,
+				"scale_x": 8,
+				"scale_y": 8
+			},
+			"type": "perlin"
+		},
+		{
+			"name": "colorize_4",
+			"node_position": {
+				"x": 24,
+				"y": 81
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0.190909,
+							"r": 0
+						},
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0.463636,
+							"r": 1
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "perlin_0",
+			"node_position": {
+				"x": 15,
+				"y": 328
+			},
+			"parameters": {
+				"iterations": 4,
+				"persistence": 0.5,
+				"scale_x": 4,
+				"scale_y": 4
+			},
+			"type": "perlin"
+		},
+		{
+			"name": "warp_0",
+			"node_position": {
+				"x": 246,
+				"y": 306
+			},
+			"parameters": {
+				"amount": 0.8,
+				"eps": 0.045,
+				"epsilon": 0
+			},
+			"type": "warp"
+		},
+		{
+			"name": "colorize_3",
+			"node_position": {
+				"x": 272,
+				"y": 171
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0.484375,
+							"g": 0.484375,
+							"pos": 0,
+							"r": 1
+						},
+						{
+							"a": 1,
+							"b": 0.744792,
+							"g": 0.744792,
+							"pos": 0.390909,
+							"r": 0.744792
+						},
+						{
+							"a": 1,
+							"b": 0.4375,
+							"g": 0.4375,
+							"pos": 1,
+							"r": 0.4375
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "blend_0",
+			"node_position": {
+				"x": 544,
+				"y": 339
+			},
+			"parameters": {
+				"amount": 0.65,
+				"blend_type": 0
+			},
+			"type": "blend"
+		},
+		{
+			"name": "colorize_2",
+			"node_position": {
+				"x": 765,
+				"y": 404
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0.791667,
+							"g": 0.908854,
+							"pos": 0,
+							"r": 1
+						},
+						{
+							"a": 1,
+							"b": 0.84375,
+							"g": 0.931641,
+							"pos": 0.236364,
+							"r": 1
+						},
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 1,
+							"r": 1
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		}
+	],
+	"parameters": {
+
+	},
+	"type": "graph"
+}

--- a/addons/material_maker/examples/metal_pattern.ptex
+++ b/addons/material_maker/examples/metal_pattern.ptex
@@ -1,1 +1,567 @@
-{"connections":[{"from":"pattern_0","from_port":0,"to":"colorize_0","to_port":0},{"from":"colorize_0","from_port":0,"to":"blend_0","to_port":0},{"from":"transform_0","from_port":0,"to":"blend_0","to_port":1},{"from":"colorize_0","from_port":0,"to":"transform_0","to_port":0},{"from":"blend_0","from_port":0,"to":"transform_1","to_port":0},{"from":"transform_1","from_port":0,"to":"blend_1","to_port":1},{"from":"blend_0","from_port":0,"to":"blend_1","to_port":0},{"from":"blend_1","from_port":0,"to":"colorize_1","to_port":0},{"from":"colorize_1","from_port":0,"to":"normal_map_0","to_port":0},{"from":"normal_map_0","from_port":0,"to":"Material","to_port":4},{"from":"perlin_0","from_port":0,"to":"colorize_2","to_port":0},{"from":"colorize_2","from_port":0,"to":"blend_2","to_port":0},{"from":"blend_2","from_port":0,"to":"Material","to_port":0},{"from":"colorize_4","from_port":0,"to":"blend_2","to_port":2},{"from":"colorize_4","from_port":0,"to":"colorize_5","to_port":0},{"from":"colorize_5","from_port":0,"to":"Material","to_port":1},{"from":"colorize_4","from_port":0,"to":"colorize_6","to_port":0},{"from":"colorize_6","from_port":0,"to":"Material","to_port":2},{"from":"perlin_1","from_port":0,"to":"blend_3","to_port":1},{"from":"colorize_7","from_port":0,"to":"blend_3","to_port":0},{"from":"blend_1","from_port":0,"to":"colorize_7","to_port":0},{"from":"blend_3","from_port":0,"to":"colorize_4","to_port":0},{"from":"uniform_0","from_port":0,"to":"blend_2","to_port":1},{"from":"colorize_5","from_port":0,"to":"combine_0","to_port":0},{"from":"colorize_6","from_port":0,"to":"combine_0","to_port":1}],"label":"Graph","name":"312","node_position":{"x":0,"y":0},"nodes":[{"name":"perlin_0","node_position":{"x":1,"y":-330},"parameters":{"iterations":7,"persistence":0.85,"scale_x":4,"scale_y":4},"type":"perlin"},{"name":"colorize_2","node_position":{"x":201,"y":-298},"parameters":{"gradient":{"points":[{"a":1,"b":0,"g":0.152344,"pos":0,"r":0.270833},{"a":1,"b":0,"g":0.191569,"pos":0.945455,"r":0.557292}],"type":"Gradient"}},"type":"colorize"},{"name":"Material","node_position":{"x":755,"y":-137},"parameters":{"albedo_color":{"a":1,"b":1,"g":1,"r":1,"type":"Color"},"ao_light_affect":1,"depth_scale":1,"emission_energy":1,"metallic":1,"normal_scale":1,"resolution":1,"roughness":1,"size":11},"type":"material"},{"name":"blend_2","node_position":{"x":407.094238,"y":-265.083313},"parameters":{"amount":1,"blend_type":0},"type":"blend"},{"name":"colorize_4","node_position":{"x":258,"y":-136},"parameters":{"gradient":{"points":[{"a":1,"b":0,"g":0,"pos":0.445455,"r":0},{"a":1,"b":1,"g":1,"pos":0.545455,"r":1}],"type":"Gradient"}},"type":"colorize"},{"name":"uniform_0","node_position":{"x":233,"y":-216},"parameters":{"color":{"a":1,"b":1,"g":1,"r":1,"type":"Color"}},"type":"uniform"},{"name":"colorize_7","node_position":{"x":-109.265503,"y":-175},"parameters":{"gradient":{"points":[{"a":1,"b":0,"g":0,"pos":0,"r":0},{"a":1,"b":1,"g":1,"pos":0.018182,"r":1}],"type":"Gradient"}},"type":"colorize"},{"name":"perlin_1","node_position":{"x":-161,"y":-86},"parameters":{"iterations":7,"persistence":0.75,"scale_x":4,"scale_y":4},"type":"perlin"},{"name":"colorize_6","node_position":{"x":444,"y":-66},"parameters":{"gradient":{"points":[{"a":1,"b":0.640625,"g":0.640625,"pos":0,"r":0.640625},{"a":1,"b":1,"g":1,"pos":1,"r":1}],"type":"Gradient"}},"type":"colorize"},{"name":"colorize_1","node_position":{"x":85,"y":72},"parameters":{"gradient":{"points":[{"a":1,"b":0,"g":0,"pos":0,"r":0},{"a":1,"b":1,"g":1,"pos":1,"r":1}],"type":"Gradient"}},"type":"colorize"},{"name":"colorize_5","node_position":{"x":446,"y":-150},"parameters":{"gradient":{"points":[{"a":1,"b":1,"g":1,"pos":0.609091,"r":1},{"a":1,"b":0,"g":0,"pos":0.645455,"r":0}],"type":"Gradient"}},"type":"colorize"},{"name":"combine_0","node_position":{"x":677,"y":-264},"parameters":{"color":{"a":1,"b":1,"g":1,"r":1,"type":"Color"},"name":0},"type":"combine"},{"name":"normal_map_0","node_position":{"x":294,"y":76},"parameters":{"amount":0.6,"param0":11,"param1":0.99,"size":2},"type":"normal_map"},{"name":"blend_3","node_position":{"x":72.734497,"y":-130},"parameters":{"amount":0.2,"blend_type":2},"type":"blend"},{"name":"transform_1","node_position":{"x":-647,"y":285},"parameters":{"repeat":true,"rotate":90,"scale_x":1,"scale_y":1,"translate_x":0.06,"translate_y":0},"type":"transform"},{"name":"blend_0","node_position":{"x":-633,"y":181},"parameters":{"amount":1,"blend_type":2},"type":"blend"},{"name":"blend_1","node_position":{"x":-632,"y":77},"parameters":{"amount":1,"blend_type":2},"type":"blend"},{"name":"colorize_0","node_position":{"x":-828,"y":218},"parameters":{"gradient":{"points":[{"a":1,"b":0,"g":0,"pos":0,"r":0},{"a":1,"b":1,"g":1,"pos":0.045455,"r":1}],"type":"Gradient"}},"type":"colorize"},{"name":"transform_0","node_position":{"x":-844,"y":279},"parameters":{"repeat":true,"rotate":0,"scale_x":1,"scale_y":1,"translate_x":0.06,"translate_y":0.06},"type":"transform"},{"name":"pattern_0","node_position":{"x":-859,"y":120},"parameters":{"mix":5,"x_scale":8,"x_wave":0,"y_scale":8,"y_wave":0},"type":"pattern"}],"parameters":{},"type":"graph"}
+{
+	"connections": [
+		{
+			"from": "pattern_0",
+			"from_port": 0,
+			"to": "colorize_0",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_0",
+			"from_port": 0,
+			"to": "blend_0",
+			"to_port": 0
+		},
+		{
+			"from": "transform_0",
+			"from_port": 0,
+			"to": "blend_0",
+			"to_port": 1
+		},
+		{
+			"from": "colorize_0",
+			"from_port": 0,
+			"to": "transform_0",
+			"to_port": 0
+		},
+		{
+			"from": "blend_0",
+			"from_port": 0,
+			"to": "transform_1",
+			"to_port": 0
+		},
+		{
+			"from": "transform_1",
+			"from_port": 0,
+			"to": "blend_1",
+			"to_port": 1
+		},
+		{
+			"from": "blend_0",
+			"from_port": 0,
+			"to": "blend_1",
+			"to_port": 0
+		},
+		{
+			"from": "blend_1",
+			"from_port": 0,
+			"to": "colorize_1",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_1",
+			"from_port": 0,
+			"to": "normal_map_0",
+			"to_port": 0
+		},
+		{
+			"from": "normal_map_0",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 4
+		},
+		{
+			"from": "perlin_0",
+			"from_port": 0,
+			"to": "colorize_2",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_2",
+			"from_port": 0,
+			"to": "blend_2",
+			"to_port": 0
+		},
+		{
+			"from": "blend_2",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_4",
+			"from_port": 0,
+			"to": "blend_2",
+			"to_port": 2
+		},
+		{
+			"from": "colorize_4",
+			"from_port": 0,
+			"to": "colorize_5",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_5",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 1
+		},
+		{
+			"from": "colorize_4",
+			"from_port": 0,
+			"to": "colorize_6",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_6",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 2
+		},
+		{
+			"from": "perlin_1",
+			"from_port": 0,
+			"to": "blend_3",
+			"to_port": 1
+		},
+		{
+			"from": "colorize_7",
+			"from_port": 0,
+			"to": "blend_3",
+			"to_port": 0
+		},
+		{
+			"from": "blend_1",
+			"from_port": 0,
+			"to": "colorize_7",
+			"to_port": 0
+		},
+		{
+			"from": "blend_3",
+			"from_port": 0,
+			"to": "colorize_4",
+			"to_port": 0
+		},
+		{
+			"from": "uniform_0",
+			"from_port": 0,
+			"to": "blend_2",
+			"to_port": 1
+		},
+		{
+			"from": "colorize_5",
+			"from_port": 0,
+			"to": "combine_0",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_6",
+			"from_port": 0,
+			"to": "combine_0",
+			"to_port": 1
+		}
+	],
+	"label": "Graph",
+	"name": "312",
+	"node_position": {
+		"x": 0,
+		"y": 0
+	},
+	"nodes": [
+		{
+			"name": "perlin_0",
+			"node_position": {
+				"x": 1,
+				"y": -330
+			},
+			"parameters": {
+				"iterations": 7,
+				"persistence": 0.85,
+				"scale_x": 4,
+				"scale_y": 4
+			},
+			"type": "perlin"
+		},
+		{
+			"name": "colorize_2",
+			"node_position": {
+				"x": 201,
+				"y": -298
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0.152344,
+							"pos": 0,
+							"r": 0.270833
+						},
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0.191569,
+							"pos": 0.945455,
+							"r": 0.557292
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "Material",
+			"node_position": {
+				"x": 755,
+				"y": -137
+			},
+			"parameters": {
+				"albedo_color": {
+					"a": 1,
+					"b": 1,
+					"g": 1,
+					"r": 1,
+					"type": "Color"
+				},
+				"ao_light_affect": 1,
+				"depth_scale": 1,
+				"emission_energy": 1,
+				"metallic": 1,
+				"normal_scale": 1,
+				"resolution": 1,
+				"roughness": 1,
+				"size": 11
+			},
+			"type": "material"
+		},
+		{
+			"name": "blend_2",
+			"node_position": {
+				"x": 407.094238,
+				"y": -265.083313
+			},
+			"parameters": {
+				"amount": 1,
+				"blend_type": 0
+			},
+			"type": "blend"
+		},
+		{
+			"name": "colorize_4",
+			"node_position": {
+				"x": 258,
+				"y": -136
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0.445455,
+							"r": 0
+						},
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0.545455,
+							"r": 1
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "uniform_0",
+			"node_position": {
+				"x": 233,
+				"y": -216
+			},
+			"parameters": {
+				"color": {
+					"a": 1,
+					"b": 1,
+					"g": 1,
+					"r": 1,
+					"type": "Color"
+				}
+			},
+			"type": "uniform"
+		},
+		{
+			"name": "colorize_7",
+			"node_position": {
+				"x": -109.265503,
+				"y": -175
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0,
+							"r": 0
+						},
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0.018182,
+							"r": 1
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "perlin_1",
+			"node_position": {
+				"x": -161,
+				"y": -86
+			},
+			"parameters": {
+				"iterations": 7,
+				"persistence": 0.75,
+				"scale_x": 4,
+				"scale_y": 4
+			},
+			"type": "perlin"
+		},
+		{
+			"name": "colorize_6",
+			"node_position": {
+				"x": 444,
+				"y": -66
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0.640625,
+							"g": 0.640625,
+							"pos": 0,
+							"r": 0.640625
+						},
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 1,
+							"r": 1
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "colorize_1",
+			"node_position": {
+				"x": 85,
+				"y": 72
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0,
+							"r": 0
+						},
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 1,
+							"r": 1
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "colorize_5",
+			"node_position": {
+				"x": 446,
+				"y": -150
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0.609091,
+							"r": 1
+						},
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0.645455,
+							"r": 0
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "combine_0",
+			"node_position": {
+				"x": 677,
+				"y": -264
+			},
+			"parameters": {
+				"color": {
+					"a": 1,
+					"b": 1,
+					"g": 1,
+					"r": 1,
+					"type": "Color"
+				},
+				"name": 0
+			},
+			"type": "combine"
+		},
+		{
+			"name": "normal_map_0",
+			"node_position": {
+				"x": 294,
+				"y": 76
+			},
+			"parameters": {
+				"amount": 0.6,
+				"param0": 11,
+				"param1": 11,
+				"param2": 1,
+				"size": 2
+			},
+			"type": "normal_map"
+		},
+		{
+			"name": "blend_3",
+			"node_position": {
+				"x": 72.734497,
+				"y": -130
+			},
+			"parameters": {
+				"amount": 0.2,
+				"blend_type": 2
+			},
+			"type": "blend"
+		},
+		{
+			"name": "transform_1",
+			"node_position": {
+				"x": -647,
+				"y": 285
+			},
+			"parameters": {
+				"repeat": true,
+				"rotate": 90,
+				"scale_x": 1,
+				"scale_y": 1,
+				"translate_x": 0.06,
+				"translate_y": 0
+			},
+			"type": "transform"
+		},
+		{
+			"name": "blend_0",
+			"node_position": {
+				"x": -633,
+				"y": 181
+			},
+			"parameters": {
+				"amount": 1,
+				"blend_type": 2
+			},
+			"type": "blend"
+		},
+		{
+			"name": "blend_1",
+			"node_position": {
+				"x": -632,
+				"y": 77
+			},
+			"parameters": {
+				"amount": 1,
+				"blend_type": 2
+			},
+			"type": "blend"
+		},
+		{
+			"name": "colorize_0",
+			"node_position": {
+				"x": -828,
+				"y": 218
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0,
+							"r": 0
+						},
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0.045455,
+							"r": 1
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "transform_0",
+			"node_position": {
+				"x": -844,
+				"y": 279
+			},
+			"parameters": {
+				"repeat": true,
+				"rotate": 0,
+				"scale_x": 1,
+				"scale_y": 1,
+				"translate_x": 0.06,
+				"translate_y": 0.06
+			},
+			"type": "transform"
+		},
+		{
+			"name": "pattern_0",
+			"node_position": {
+				"x": -859,
+				"y": 120
+			},
+			"parameters": {
+				"mix": 5,
+				"x_scale": 8,
+				"x_wave": 0,
+				"y_scale": 8,
+				"y_wave": 0
+			},
+			"type": "pattern"
+		}
+	],
+	"parameters": {
+
+	},
+	"type": "graph"
+}

--- a/addons/material_maker/examples/metal_pattern_2.ptex
+++ b/addons/material_maker/examples/metal_pattern_2.ptex
@@ -1,1 +1,185 @@
-{"connections":[{"from":"pattern_0","from_port":0,"to":"colorize_0","to_port":0},{"from":"transform_2","from_port":0,"to":"blend_0","to_port":0},{"from":"pattern_1","from_port":0,"to":"blend_0","to_port":2},{"from":"blend_0","from_port":0,"to":"normal_map_0","to_port":0},{"from":"normal_map_0","from_port":0,"to":"Material","to_port":4},{"from":"colorize_0","from_port":0,"to":"transform_2","to_port":0},{"from":"colorize_0","from_port":0,"to":"blend_0","to_port":1}],"label":"Graph","name":"327","node_position":{"x":0,"y":0},"nodes":[{"name":"pattern_1","node_position":{"x":78,"y":382},"parameters":{"mix":4,"x_scale":4,"x_wave":2,"y_scale":4,"y_wave":2},"type":"pattern"},{"name":"colorize_0","node_position":{"x":148,"y":258},"parameters":{"gradient":{"points":[{"a":1,"b":1,"g":1,"pos":0.181818,"r":1},{"a":1,"b":0,"g":0,"pos":0.436364,"r":0}],"type":"Gradient"}},"type":"colorize"},{"name":"pattern_0","node_position":{"x":-127,"y":256},"parameters":{"mix":0,"x_scale":40,"x_wave":1,"y_scale":8,"y_wave":1},"type":"pattern"},{"name":"transform_2","node_position":{"x":372,"y":37},"parameters":{"repeat":true,"rotate":90,"scale_x":1,"scale_y":1,"translate_x":0,"translate_y":0},"type":"transform"},{"name":"Material","node_position":{"x":930,"y":199},"parameters":{"albedo_color":{"a":1,"b":0.953125,"g":0.834013,"r":0.822815,"type":"Color"},"ao_light_affect":1,"depth_scale":1,"emission_energy":1,"metallic":1,"normal_scale":1,"resolution":1,"roughness":0.75,"size":11},"type":"material"},{"name":"normal_map_0","node_position":{"x":668,"y":268},"parameters":{"amount":0.5,"param0":11,"param1":0.99,"size":2},"type":"normal_map"},{"name":"blend_0","node_position":{"x":381,"y":252},"parameters":{"amount":1,"blend_type":0},"type":"blend"}],"parameters":{},"type":"graph"}
+{
+	"connections": [
+		{
+			"from": "pattern_0",
+			"from_port": 0,
+			"to": "colorize_0",
+			"to_port": 0
+		},
+		{
+			"from": "transform_2",
+			"from_port": 0,
+			"to": "blend_0",
+			"to_port": 0
+		},
+		{
+			"from": "pattern_1",
+			"from_port": 0,
+			"to": "blend_0",
+			"to_port": 2
+		},
+		{
+			"from": "blend_0",
+			"from_port": 0,
+			"to": "normal_map_0",
+			"to_port": 0
+		},
+		{
+			"from": "normal_map_0",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 4
+		},
+		{
+			"from": "colorize_0",
+			"from_port": 0,
+			"to": "transform_2",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_0",
+			"from_port": 0,
+			"to": "blend_0",
+			"to_port": 1
+		}
+	],
+	"label": "Graph",
+	"name": "327",
+	"node_position": {
+		"x": 0,
+		"y": 0
+	},
+	"nodes": [
+		{
+			"name": "pattern_1",
+			"node_position": {
+				"x": 78,
+				"y": 382
+			},
+			"parameters": {
+				"mix": 4,
+				"x_scale": 4,
+				"x_wave": 2,
+				"y_scale": 4,
+				"y_wave": 2
+			},
+			"type": "pattern"
+		},
+		{
+			"name": "colorize_0",
+			"node_position": {
+				"x": 148,
+				"y": 258
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0.181818,
+							"r": 1
+						},
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0.436364,
+							"r": 0
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "pattern_0",
+			"node_position": {
+				"x": -127,
+				"y": 256
+			},
+			"parameters": {
+				"mix": 0,
+				"x_scale": 40,
+				"x_wave": 1,
+				"y_scale": 8,
+				"y_wave": 1
+			},
+			"type": "pattern"
+		},
+		{
+			"name": "transform_2",
+			"node_position": {
+				"x": 372,
+				"y": 37
+			},
+			"parameters": {
+				"repeat": true,
+				"rotate": 90,
+				"scale_x": 1,
+				"scale_y": 1,
+				"translate_x": 0,
+				"translate_y": 0
+			},
+			"type": "transform"
+		},
+		{
+			"name": "Material",
+			"node_position": {
+				"x": 930,
+				"y": 199
+			},
+			"parameters": {
+				"albedo_color": {
+					"a": 1,
+					"b": 0.953125,
+					"g": 0.834013,
+					"r": 0.822815,
+					"type": "Color"
+				},
+				"ao_light_affect": 1,
+				"depth_scale": 1,
+				"emission_energy": 1,
+				"metallic": 1,
+				"normal_scale": 1,
+				"resolution": 1,
+				"roughness": 0.75,
+				"size": 11
+			},
+			"type": "material"
+		},
+		{
+			"name": "normal_map_0",
+			"node_position": {
+				"x": 668,
+				"y": 268
+			},
+			"parameters": {
+				"amount": 0.5,
+				"param0": 11,
+				"param1": 11,
+				"param2": 1,
+				"size": 2
+			},
+			"type": "normal_map"
+		},
+		{
+			"name": "blend_0",
+			"node_position": {
+				"x": 381,
+				"y": 252
+			},
+			"parameters": {
+				"amount": 1,
+				"blend_type": 0
+			},
+			"type": "blend"
+		}
+	],
+	"parameters": {
+
+	},
+	"type": "graph"
+}

--- a/addons/material_maker/examples/metal_pattern_3.ptex
+++ b/addons/material_maker/examples/metal_pattern_3.ptex
@@ -1,1 +1,261 @@
-{"connections":[{"from":"normal_map_0","from_port":0,"to":"Material","to_port":4},{"from":"pattern_1","from_port":0,"to":"colorize_1","to_port":0},{"from":"colorize_0","from_port":0,"to":"blend_0","to_port":1},{"from":"colorize_1","from_port":0,"to":"blend_0","to_port":0},{"from":"blend_0","from_port":0,"to":"normal_map_0","to_port":0},{"from":"uniform_0","from_port":0,"to":"Material","to_port":0},{"from":"uniform_1","from_port":0,"to":"Material","to_port":1},{"from":"uniform_2","from_port":0,"to":"Material","to_port":2},{"from":"pattern_0","from_port":0,"to":"colorize_0","to_port":0}],"label":"Graph","name":"342","node_position":{"x":0,"y":0},"nodes":[{"name":"colorize_1","node_position":{"x":-16,"y":97},"parameters":{"gradient":{"points":[{"a":1,"b":0,"g":0,"pos":0.236364,"r":0},{"a":1,"b":1,"g":1,"pos":0.254545,"r":1}],"type":"Gradient"}},"type":"colorize"},{"name":"Material","node_position":{"x":508,"y":116},"parameters":{"albedo_color":{"a":1,"b":1,"g":1,"r":1,"type":"Color"},"ao_light_affect":1,"depth_scale":1,"emission_energy":1,"metallic":1,"normal_scale":1,"resolution":1,"roughness":1,"size":11},"type":"material"},{"name":"normal_map_0","node_position":{"x":257,"y":286},"parameters":{"amount":0.5,"param0":11,"param1":0.99,"size":2},"type":"normal_map"},{"name":"uniform_0","node_position":{"x":330,"y":33},"parameters":{"color":{"a":1,"b":0.855469,"g":0.736813,"r":0.51796,"type":"Color"}},"type":"uniform"},{"name":"uniform_1","node_position":{"x":333,"y":85},"parameters":{"color":{"a":1,"b":1,"g":1,"r":1,"type":"Color"}},"type":"uniform"},{"name":"uniform_2","node_position":{"x":336,"y":138},"parameters":{"color":{"a":1,"b":0.632813,"g":0.632813,"r":0.632813,"type":"Color"}},"type":"uniform"},{"name":"pattern_1","node_position":{"x":-46,"y":-2},"parameters":{"mix":3,"x_scale":1,"x_wave":1,"y_scale":1,"y_wave":1},"type":"pattern"},{"name":"pattern_0","node_position":{"x":-32,"y":191},"parameters":{"mix":0,"x_scale":16,"x_wave":0,"y_scale":16,"y_wave":0},"type":"pattern"},{"name":"blend_0","node_position":{"x":254,"y":196},"parameters":{"amount":1,"blend_type":9},"type":"blend"},{"name":"colorize_0","node_position":{"x":-15,"y":289},"parameters":{"gradient":{"points":[{"a":1,"b":0.546875,"g":0.546875,"pos":0.845455,"r":0.546875},{"a":1,"b":0,"g":0,"pos":1,"r":0}],"type":"Gradient"}},"type":"colorize"}],"parameters":{},"type":"graph"}
+{
+	"connections": [
+		{
+			"from": "normal_map_0",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 4
+		},
+		{
+			"from": "pattern_1",
+			"from_port": 0,
+			"to": "colorize_1",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_0",
+			"from_port": 0,
+			"to": "blend_0",
+			"to_port": 1
+		},
+		{
+			"from": "colorize_1",
+			"from_port": 0,
+			"to": "blend_0",
+			"to_port": 0
+		},
+		{
+			"from": "blend_0",
+			"from_port": 0,
+			"to": "normal_map_0",
+			"to_port": 0
+		},
+		{
+			"from": "uniform_0",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 0
+		},
+		{
+			"from": "uniform_1",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 1
+		},
+		{
+			"from": "uniform_2",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 2
+		},
+		{
+			"from": "pattern_0",
+			"from_port": 0,
+			"to": "colorize_0",
+			"to_port": 0
+		}
+	],
+	"label": "Graph",
+	"name": "342",
+	"node_position": {
+		"x": 0,
+		"y": 0
+	},
+	"nodes": [
+		{
+			"name": "colorize_1",
+			"node_position": {
+				"x": -16,
+				"y": 97
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0.236364,
+							"r": 0
+						},
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0.254545,
+							"r": 1
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "Material",
+			"node_position": {
+				"x": 508,
+				"y": 116
+			},
+			"parameters": {
+				"albedo_color": {
+					"a": 1,
+					"b": 1,
+					"g": 1,
+					"r": 1,
+					"type": "Color"
+				},
+				"ao_light_affect": 1,
+				"depth_scale": 1,
+				"emission_energy": 1,
+				"metallic": 1,
+				"normal_scale": 1,
+				"resolution": 1,
+				"roughness": 1,
+				"size": 11
+			},
+			"type": "material"
+		},
+		{
+			"name": "normal_map_0",
+			"node_position": {
+				"x": 257,
+				"y": 286
+			},
+			"parameters": {
+				"amount": 0.5,
+				"param0": 11,
+				"param1": 11,
+				"param2": 1,
+				"size": 2
+			},
+			"type": "normal_map"
+		},
+		{
+			"name": "uniform_0",
+			"node_position": {
+				"x": 330,
+				"y": 33
+			},
+			"parameters": {
+				"color": {
+					"a": 1,
+					"b": 0.855469,
+					"g": 0.736813,
+					"r": 0.51796,
+					"type": "Color"
+				}
+			},
+			"type": "uniform"
+		},
+		{
+			"name": "uniform_1",
+			"node_position": {
+				"x": 333,
+				"y": 85
+			},
+			"parameters": {
+				"color": {
+					"a": 1,
+					"b": 1,
+					"g": 1,
+					"r": 1,
+					"type": "Color"
+				}
+			},
+			"type": "uniform"
+		},
+		{
+			"name": "uniform_2",
+			"node_position": {
+				"x": 336,
+				"y": 138
+			},
+			"parameters": {
+				"color": {
+					"a": 1,
+					"b": 0.632813,
+					"g": 0.632813,
+					"r": 0.632813,
+					"type": "Color"
+				}
+			},
+			"type": "uniform"
+		},
+		{
+			"name": "pattern_1",
+			"node_position": {
+				"x": -46,
+				"y": -2
+			},
+			"parameters": {
+				"mix": 3,
+				"x_scale": 1,
+				"x_wave": 1,
+				"y_scale": 1,
+				"y_wave": 1
+			},
+			"type": "pattern"
+		},
+		{
+			"name": "pattern_0",
+			"node_position": {
+				"x": -32,
+				"y": 191
+			},
+			"parameters": {
+				"mix": 0,
+				"x_scale": 16,
+				"x_wave": 0,
+				"y_scale": 16,
+				"y_wave": 0
+			},
+			"type": "pattern"
+		},
+		{
+			"name": "blend_0",
+			"node_position": {
+				"x": 254,
+				"y": 196
+			},
+			"parameters": {
+				"amount": 1,
+				"blend_type": 9
+			},
+			"type": "blend"
+		},
+		{
+			"name": "colorize_0",
+			"node_position": {
+				"x": -15,
+				"y": 289
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0.546875,
+							"g": 0.546875,
+							"pos": 0.845455,
+							"r": 0.546875
+						},
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 1,
+							"r": 0
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		}
+	],
+	"parameters": {
+
+	},
+	"type": "graph"
+}

--- a/addons/material_maker/examples/mosaic.ptex
+++ b/addons/material_maker/examples/mosaic.ptex
@@ -1,1 +1,246 @@
-{"connections":[{"from":"blend_0","from_port":0,"to":"Material","to_port":0},{"from":"voronoi_0","from_port":2,"to":"blend_0","to_port":1},{"from":"voronoi_0","from_port":1,"to":"colorize_0","to_port":0},{"from":"colorize_0","from_port":0,"to":"blend_0","to_port":0},{"from":"voronoi_0","from_port":1,"to":"colorize_1","to_port":0},{"from":"colorize_1","from_port":0,"to":"normal_map_0","to_port":0},{"from":"normal_map_0","from_port":0,"to":"Material","to_port":4},{"from":"uniform_0","from_port":0,"to":"Material","to_port":1},{"from":"voronoi_0","from_port":1,"to":"colorize_2","to_port":0},{"from":"colorize_2","from_port":0,"to":"Material","to_port":2}],"label":"Graph","name":"448","node_position":{"x":0,"y":0},"nodes":[{"name":"voronoi_0","node_position":{"x":-543.5,"y":-11.5},"parameters":{"intensity":1,"randomness":1,"scale_x":32,"scale_y":32},"type":"voronoi"},{"name":"normal_map_0","node_position":{"x":-260.5,"y":128.5},"parameters":{"amount":0.5,"param0":11,"param1":0.99,"size":5},"type":"normal_map"},{"name":"Material","node_position":{"x":30,"y":-44},"parameters":{"albedo_color":{"a":1,"b":1,"g":1,"r":1,"type":"Color"},"ao_light_affect":1,"depth_scale":1,"emission_energy":1,"metallic":1,"normal_scale":1,"resolution":1,"roughness":1,"size":11},"type":"material"},{"name":"colorize_1","node_position":{"x":-490.5,"y":135.5},"parameters":{"gradient":{"points":[{"a":1,"b":0,"g":0,"pos":0.054546,"r":0},{"a":1,"b":1,"g":1,"pos":0.127273,"r":1}],"type":"Gradient"}},"type":"colorize"},{"name":"colorize_0","node_position":{"x":-317.5,"y":-169.5},"parameters":{"gradient":{"points":[{"a":1,"b":1,"g":1,"pos":0.063636,"r":1},{"a":1,"b":0,"g":0,"pos":0.072727,"r":0}],"type":"Gradient"}},"type":"colorize"},{"name":"uniform_0","node_position":{"x":-127.5,"y":-3.5},"parameters":{"color":{"a":1,"b":0.109375,"g":0.109375,"r":0.109375,"type":"Color"}},"type":"uniform"},{"name":"colorize_2","node_position":{"x":-306.5,"y":39.5},"parameters":{"gradient":{"points":[{"a":1,"b":1,"g":1,"pos":0,"r":1},{"a":1,"b":0.109375,"g":0.109375,"pos":0.236364,"r":0.109375}],"type":"Gradient"}},"type":"colorize"},{"name":"blend_0","node_position":{"x":-294.5,"y":-94.5},"parameters":{"amount":1,"blend_type":3},"type":"blend"}],"parameters":{},"type":"graph"}
+{
+	"connections": [
+		{
+			"from": "blend_0",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 0
+		},
+		{
+			"from": "voronoi_0",
+			"from_port": 2,
+			"to": "blend_0",
+			"to_port": 1
+		},
+		{
+			"from": "voronoi_0",
+			"from_port": 1,
+			"to": "colorize_0",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_0",
+			"from_port": 0,
+			"to": "blend_0",
+			"to_port": 0
+		},
+		{
+			"from": "voronoi_0",
+			"from_port": 1,
+			"to": "colorize_1",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_1",
+			"from_port": 0,
+			"to": "normal_map_0",
+			"to_port": 0
+		},
+		{
+			"from": "normal_map_0",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 4
+		},
+		{
+			"from": "uniform_0",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 1
+		},
+		{
+			"from": "voronoi_0",
+			"from_port": 1,
+			"to": "colorize_2",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_2",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 2
+		}
+	],
+	"label": "Graph",
+	"name": "448",
+	"node_position": {
+		"x": 0,
+		"y": 0
+	},
+	"nodes": [
+		{
+			"name": "voronoi_0",
+			"node_position": {
+				"x": -543.5,
+				"y": -11.5
+			},
+			"parameters": {
+				"intensity": 1,
+				"randomness": 1,
+				"scale_x": 32,
+				"scale_y": 32
+			},
+			"type": "voronoi"
+		},
+		{
+			"name": "normal_map_0",
+			"node_position": {
+				"x": -260.5,
+				"y": 128.5
+			},
+			"parameters": {
+				"amount": 0.5,
+				"param0": 11,
+				"param1": 11,
+				"param2": 1,
+				"size": 5
+			},
+			"type": "normal_map"
+		},
+		{
+			"name": "Material",
+			"node_position": {
+				"x": 30,
+				"y": -44
+			},
+			"parameters": {
+				"albedo_color": {
+					"a": 1,
+					"b": 1,
+					"g": 1,
+					"r": 1,
+					"type": "Color"
+				},
+				"ao_light_affect": 1,
+				"depth_scale": 1,
+				"emission_energy": 1,
+				"metallic": 1,
+				"normal_scale": 1,
+				"resolution": 1,
+				"roughness": 1,
+				"size": 11
+			},
+			"type": "material"
+		},
+		{
+			"name": "colorize_1",
+			"node_position": {
+				"x": -490.5,
+				"y": 135.5
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0.054546,
+							"r": 0
+						},
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0.127273,
+							"r": 1
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "colorize_0",
+			"node_position": {
+				"x": -317.5,
+				"y": -169.5
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0.063636,
+							"r": 1
+						},
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0.072727,
+							"r": 0
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "uniform_0",
+			"node_position": {
+				"x": -127.5,
+				"y": -3.5
+			},
+			"parameters": {
+				"color": {
+					"a": 1,
+					"b": 0.109375,
+					"g": 0.109375,
+					"r": 0.109375,
+					"type": "Color"
+				}
+			},
+			"type": "uniform"
+		},
+		{
+			"name": "colorize_2",
+			"node_position": {
+				"x": -306.5,
+				"y": 39.5
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0,
+							"r": 1
+						},
+						{
+							"a": 1,
+							"b": 0.109375,
+							"g": 0.109375,
+							"pos": 0.236364,
+							"r": 0.109375
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "blend_0",
+			"node_position": {
+				"x": -294.5,
+				"y": -94.5
+			},
+			"parameters": {
+				"amount": 1,
+				"blend_type": 3
+			},
+			"type": "blend"
+		}
+	],
+	"parameters": {
+
+	},
+	"type": "graph"
+}

--- a/addons/material_maker/examples/paper.ptex
+++ b/addons/material_maker/examples/paper.ptex
@@ -1,1 +1,342 @@
-{"connections":[{"from":"pattern_0","from_port":0,"to":"colorize_0","to_port":0},{"from":"pattern_1","from_port":0,"to":"colorize_1","to_port":0},{"from":"colorize_0","from_port":0,"to":"blend_0","to_port":0},{"from":"colorize_1","from_port":0,"to":"blend_0","to_port":1},{"from":"blend_0","from_port":0,"to":"Material","to_port":0},{"from":"shape_0","from_port":0,"to":"colorize_2","to_port":0},{"from":"colorize_2","from_port":0,"to":"transform_0","to_port":0},{"from":"perlin_1","from_port":0,"to":"transform_0","to_port":1},{"from":"colorize_3","from_port":0,"to":"blend_1","to_port":0},{"from":"transform_0","from_port":0,"to":"blend_1","to_port":1},{"from":"perlin_1","from_port":0,"to":"colorize_3","to_port":0}],"label":"Graph","name":"466","node_position":{"x":0,"y":0},"nodes":[{"name":"Material","node_position":{"x":479,"y":-5},"parameters":{"albedo_color":{"a":1,"b":1,"g":1,"r":1,"type":"Color"},"ao_light_affect":1,"depth_scale":1,"emission_energy":1,"metallic":1,"normal_scale":1,"resolution":1,"roughness":1,"size":11},"type":"material"},{"name":"pattern_1","node_position":{"x":-295.25,"y":-24.25},"parameters":{"mix":3,"x_scale":8,"x_wave":1,"y_scale":8,"y_wave":1},"type":"pattern"},{"name":"pattern_0","node_position":{"x":-303,"y":-157},"parameters":{"mix":3,"x_scale":4,"x_wave":4,"y_scale":32,"y_wave":1},"type":"pattern"},{"name":"colorize_1","node_position":{"x":-13.25,"y":-31.25},"parameters":{"gradient":{"points":[{"a":1,"b":1,"g":0.752604,"pos":0.036364,"r":0.583333},{"a":1,"b":1,"g":1,"pos":0.054545,"r":1}],"type":"Gradient"}},"type":"colorize"},{"name":"colorize_0","node_position":{"x":-34,"y":-153},"parameters":{"gradient":{"points":[{"a":1,"b":1,"g":0.752604,"pos":0.054545,"r":0.583333},{"a":1,"b":1,"g":1,"pos":0.081818,"r":1}],"type":"Gradient"}},"type":"colorize"},{"name":"blend_0","node_position":{"x":231,"y":5.5},"parameters":{"amount":1,"blend_type":10},"type":"blend"},{"name":"perlin_0","node_position":{"x":-27.999969,"y":111},"parameters":{"iterations":3,"persistence":0.5,"scale_x":4,"scale_y":4},"type":"perlin"},{"name":"shape_0","node_position":{"x":-300.999969,"y":281},"parameters":{"edge":0.465753,"radius":0.452055,"shape":1,"sides":4},"type":"shape"},{"name":"colorize_2","node_position":{"x":-137.999969,"y":291},"parameters":{"gradient":{"points":[{"a":1,"b":0,"g":0,"pos":0.3,"r":0},{"a":1,"b":1,"g":1,"pos":0.509091,"r":1},{"a":1,"b":0,"g":0,"pos":0.754545,"r":0}],"type":"Gradient"}},"type":"colorize"},{"name":"perlin_1","node_position":{"x":-267.999969,"y":487},"parameters":{"iterations":6,"persistence":0.5,"scale_x":16,"scale_y":16},"type":"perlin"},{"name":"blend_1","node_position":{"x":312.000031,"y":380.5},"parameters":{"amount":1,"blend_type":0},"type":"blend"},{"name":"colorize_3","node_position":{"x":48.000031,"y":499.5},"parameters":{"gradient":{"points":[{"a":1,"b":0,"g":0,"pos":0,"r":0},{"a":1,"b":1,"g":1,"pos":1,"r":1}],"type":"Gradient"}},"type":"colorize"},{"name":"transform_0","node_position":{"x":66.000031,"y":250.5},"parameters":{"repeat":true,"rotate":0,"scale_x":1,"scale_y":1,"translate_x":0.01,"translate_y":0},"type":"transform"}],"parameters":{},"type":"graph"}
+{
+	"connections": [
+		{
+			"from": "pattern_0",
+			"from_port": 0,
+			"to": "colorize_0",
+			"to_port": 0
+		},
+		{
+			"from": "pattern_1",
+			"from_port": 0,
+			"to": "colorize_1",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_0",
+			"from_port": 0,
+			"to": "blend_0",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_1",
+			"from_port": 0,
+			"to": "blend_0",
+			"to_port": 1
+		},
+		{
+			"from": "blend_0",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 0
+		},
+		{
+			"from": "shape_0",
+			"from_port": 0,
+			"to": "colorize_2",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_2",
+			"from_port": 0,
+			"to": "transform_0",
+			"to_port": 0
+		},
+		{
+			"from": "perlin_1",
+			"from_port": 0,
+			"to": "transform_0",
+			"to_port": 1
+		},
+		{
+			"from": "colorize_3",
+			"from_port": 0,
+			"to": "blend_1",
+			"to_port": 0
+		},
+		{
+			"from": "transform_0",
+			"from_port": 0,
+			"to": "blend_1",
+			"to_port": 1
+		},
+		{
+			"from": "perlin_1",
+			"from_port": 0,
+			"to": "colorize_3",
+			"to_port": 0
+		}
+	],
+	"label": "Graph",
+	"name": "466",
+	"node_position": {
+		"x": 0,
+		"y": 0
+	},
+	"nodes": [
+		{
+			"name": "Material",
+			"node_position": {
+				"x": 479,
+				"y": -5
+			},
+			"parameters": {
+				"albedo_color": {
+					"a": 1,
+					"b": 1,
+					"g": 1,
+					"r": 1,
+					"type": "Color"
+				},
+				"ao_light_affect": 1,
+				"depth_scale": 1,
+				"emission_energy": 1,
+				"metallic": 1,
+				"normal_scale": 1,
+				"resolution": 1,
+				"roughness": 1,
+				"size": 11
+			},
+			"type": "material"
+		},
+		{
+			"name": "pattern_1",
+			"node_position": {
+				"x": -295.25,
+				"y": -24.25
+			},
+			"parameters": {
+				"mix": 3,
+				"x_scale": 8,
+				"x_wave": 1,
+				"y_scale": 8,
+				"y_wave": 1
+			},
+			"type": "pattern"
+		},
+		{
+			"name": "pattern_0",
+			"node_position": {
+				"x": -303,
+				"y": -157
+			},
+			"parameters": {
+				"mix": 3,
+				"x_scale": 4,
+				"x_wave": 4,
+				"y_scale": 32,
+				"y_wave": 1
+			},
+			"type": "pattern"
+		},
+		{
+			"name": "colorize_1",
+			"node_position": {
+				"x": -13.25,
+				"y": -31.25
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 1,
+							"g": 0.752604,
+							"pos": 0.036364,
+							"r": 0.583333
+						},
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0.054545,
+							"r": 1
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "colorize_0",
+			"node_position": {
+				"x": -34,
+				"y": -153
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 1,
+							"g": 0.752604,
+							"pos": 0.054545,
+							"r": 0.583333
+						},
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0.081818,
+							"r": 1
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "blend_0",
+			"node_position": {
+				"x": 231,
+				"y": 5.5
+			},
+			"parameters": {
+				"amount": 1,
+				"blend_type": 10
+			},
+			"type": "blend"
+		},
+		{
+			"name": "perlin_0",
+			"node_position": {
+				"x": -27.999969,
+				"y": 111
+			},
+			"parameters": {
+				"iterations": 3,
+				"persistence": 0.5,
+				"scale_x": 4,
+				"scale_y": 4
+			},
+			"type": "perlin"
+		},
+		{
+			"name": "shape_0",
+			"node_position": {
+				"x": -300.999969,
+				"y": 281
+			},
+			"parameters": {
+				"edge": 0.465753,
+				"radius": 0.452055,
+				"shape": 1,
+				"sides": 4
+			},
+			"type": "shape"
+		},
+		{
+			"name": "colorize_2",
+			"node_position": {
+				"x": -137.999969,
+				"y": 291
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0.3,
+							"r": 0
+						},
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0.509091,
+							"r": 1
+						},
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0.754545,
+							"r": 0
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "perlin_1",
+			"node_position": {
+				"x": -267.999969,
+				"y": 487
+			},
+			"parameters": {
+				"iterations": 6,
+				"persistence": 0.5,
+				"scale_x": 16,
+				"scale_y": 16
+			},
+			"type": "perlin"
+		},
+		{
+			"name": "blend_1",
+			"node_position": {
+				"x": 312.000031,
+				"y": 380.5
+			},
+			"parameters": {
+				"amount": 1,
+				"blend_type": 0
+			},
+			"type": "blend"
+		},
+		{
+			"name": "colorize_3",
+			"node_position": {
+				"x": 48.000031,
+				"y": 499.5
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0,
+							"r": 0
+						},
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 1,
+							"r": 1
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "transform_0",
+			"node_position": {
+				"x": 66.000031,
+				"y": 250.5
+			},
+			"parameters": {
+				"repeat": true,
+				"rotate": 0,
+				"scale_x": 1,
+				"scale_y": 1,
+				"translate_x": 0.01,
+				"translate_y": 0
+			},
+			"type": "transform"
+		}
+	],
+	"parameters": {
+
+	},
+	"type": "graph"
+}

--- a/addons/material_maker/examples/pentagram.ptex
+++ b/addons/material_maker/examples/pentagram.ptex
@@ -1,1 +1,536 @@
-{"connections":[{"from":"shape_2","from_port":0,"to":"colorize_2_2","to_port":0},{"from":"graph","from_port":0,"to":"blend_2_2","to_port":0},{"from":"colorize_2_2","from_port":0,"to":"blend_2_2","to_port":1},{"from":"blend_2_2","from_port":0,"to":"colorize_3","to_port":0},{"from":"colorize_3","from_port":0,"to":"Material","to_port":3}],"label":"Graph","name":"39","node_position":{"x":0,"y":0},"nodes":[{"name":"Material","node_position":{"x":193,"y":-49},"parameters":{"albedo_color":{"a":1,"b":0,"g":0,"r":0,"type":"Color"},"ao_light_affect":1,"depth_scale":1,"emission_energy":1,"metallic":1,"normal_scale":1,"roughness":1,"size":11},"type":"material"},{"name":"shape_2","node_position":{"x":-533.992065,"y":-0.5},"parameters":{"edge":1,"radius":0.25,"shape":2,"sides":5},"type":"shape"},{"name":"colorize_2_2","node_position":{"x":-363.992096,"y":-7},"parameters":{"gradient":{"points":[{"a":1,"b":0,"g":0,"pos":0.027273,"r":0},{"a":1,"b":1,"g":1,"pos":0.118182,"r":1},{"a":1,"b":0,"g":0,"pos":0.143066,"r":0}],"type":"Gradient"}},"type":"colorize"},{"name":"blend_2_2","node_position":{"x":-38.492065,"y":139},"parameters":{"amount":1,"blend_type":9},"type":"blend"},{"name":"colorize_3","node_position":{"x":106.007935,"y":-288.5},"parameters":{"gradient":{"points":[{"a":1,"b":0,"g":0,"pos":0,"r":0},{"a":1,"b":0,"g":0,"pos":1,"r":1}],"type":"Gradient"}},"type":"colorize"},{"connections":[{"from":"_2","from_port":0,"to":"transform","to_port":0},{"from":"transform","from_port":0,"to":"_3","to_port":0},{"from":"shape","from_port":0,"to":"colorize","to_port":0},{"from":"colorize","from_port":0,"to":"blend","to_port":0},{"from":"_3","from_port":0,"to":"blend","to_port":1},{"from":"shape","from_port":0,"to":"colorize_2","to_port":0},{"from":"blend","from_port":0,"to":"blend_2","to_port":0},{"from":"colorize_2","from_port":0,"to":"blend_2","to_port":1},{"from":"blend_2","from_port":0,"to":"gen_outputs","to_port":0}],"label":"Runes circle","name":"graph","node_position":{"x":-271.03067,"y":-132},"nodes":[{"name":"_2","node_position":{"x":-400.5,"y":-278.5},"parameters":{"columns":64,"rows":8,"thickness":0.1},"shader_model":{"global":"// Based on Otavio Good's https://www.shadertoy.com/view/MsXSRn\n\nfloat ThickLine(vec2 uv, vec2 posA, vec2 posB, float radiusInv)\n{\n\tvec2 dir = posA - posB;\n\tfloat dirLen = length(dir);\n\tvec2 dirN = normalize(dir);\n\tfloat dotTemp = clamp(dot(uv - posB, dirN), 0.0, dirLen);\n\tvec2 proj = dotTemp * dirN + posB;\n\tfloat d1 = length(uv - proj);\n\tfloat finalGray = clamp(1.0 - d1 * radiusInv, 0.0, 1.0);\n\treturn finalGray;\n}\n\n// makes a rune in the 0..1 uv space. Seed is which rune to draw.\n// passes back gray in x and derivates for lighting in yz\nfloat Rune(vec2 uv, float thickness) {\n\tfloat finalLine = 0.0;\n\tvec2 seed = floor(uv)-0.41;\n\tuv = fract(uv);\n\tfor (int i = 0; i < 4; i++)\t// number of strokes\n\t{\n\t\tvec2 posA = rand2(floor(seed+0.5));\n\t\tvec2 posB = rand2(floor(seed+1.5));\n\t\tseed += 2.0;\n\t\t// expand the range and mod it to get a nicely distributed random number - hopefully. :)\n\t\tposA = fract(posA * 128.0);\n\t\tposB = fract(posB * 128.0);\n\t\t// each rune touches the edge of its box on all 4 sides\n\t\tif (i == 0) posA.y = 0.0;\n\t\tif (i == 1) posA.x = 0.999;\n\t\tif (i == 2) posA.x = 0.0;\n\t\tif (i == 3) posA.y = 0.999;\n\t\t// snap the random line endpoints to a grid 2x3\n\t\tvec2 snaps = vec2(2.0, 3.0);\n\t\tposA = (floor(posA * snaps) + 0.5) / snaps;\t// + 0.5 to center it in a grid cell\n\t\tposB = (floor(posB * snaps) + 0.5) / snaps;\n\t\t//if (distance(posA, posB) < 0.0001) continue;\t// eliminate dots.\n\t\t// Dots (degenerate lines) are not cross-GPU safe without adding 0.001 - divide by 0 error.\n\t\tfinalLine = max(finalLine, ThickLine(uv, posA, posB + 0.001, 1.0/max(0.01, thickness)));\n\t}\n\treturn finalLine;\n}\n\n\n","inputs":[],"instance":"","name":"Runes","outputs":[{"f":"Rune(vec2($columns, $rows)*$uv, $thickness)","type":"f"}],"parameters":[{"default":0,"label":"","max":32,"min":2,"name":"columns","step":1,"type":"float","widget":"spinbox"},{"default":0,"label":"","max":32,"min":2,"name":"rows","step":1,"type":"float","widget":"spinbox"},{"default":0.1,"label":"","max":0.3,"min":0,"name":"thickness","step":0.01,"type":"float"}]},"type":"shader"},{"name":"transform","node_position":{"x":-437.5,"y":-153.5},"parameters":{"repeat":true,"rotate":0,"scale_x":8,"scale_y":1,"translate_x":0,"translate_y":-0.04},"type":"transform"},{"name":"shape","node_position":{"x":-156.068481,"y":-262.5},"parameters":{"edge":0.299221,"radius":1,"shape":0,"sides":3},"type":"shape"},{"name":"colorize","node_position":{"x":-174.853485,"y":-165.5},"parameters":{"gradient":{"points":[{"a":1,"b":0,"g":0,"pos":0.1,"r":0},{"a":1,"b":1,"g":1,"pos":0.154545,"r":1},{"a":1,"b":1,"g":1,"pos":0.545455,"r":1},{"a":1,"b":0,"g":0,"pos":0.618182,"r":0}],"type":"Gradient"}},"type":"colorize"},{"name":"blend","node_position":{"x":-195.853485,"y":-107.5},"parameters":{"amount":1,"blend_type":2},"type":"blend"},{"name":"colorize_2","node_position":{"x":-167.853485,"y":-26.5},"parameters":{"gradient":{"points":[{"a":1,"b":0,"g":0,"pos":0.018182,"r":0},{"a":1,"b":1,"g":1,"pos":0.081819,"r":1},{"a":1,"b":0,"g":0,"pos":0.115793,"r":0},{"a":1,"b":0,"g":0,"pos":0.570339,"r":0},{"a":1,"b":1,"g":1,"pos":0.633975,"r":1},{"a":1,"b":0,"g":0,"pos":0.663637,"r":0}],"type":"Gradient"}},"type":"colorize"},{"name":"_3","node_position":{"x":-390.5,"y":41.5},"parameters":{},"shader_model":{"global":"","inputs":[{"default":"0.0","label":"","name":"in","type":"rgba"}],"instance":"","name":"DiscMap","outputs":[{"rgba":"$in(vec2(atan($uv.y-0.5, $uv.x-0.5), 2.0*length($uv-vec2(0.5))))","type":"rgba"}],"parameters":[]},"type":"shader"},{"name":"blend_2","node_position":{"x":-197.116241,"y":32.5},"parameters":{"amount":1,"blend_type":9},"type":"blend"},{"name":"gen_outputs","node_position":{"x":143.931519,"y":-115},"parameters":{},"ports":[{"name":"port0","type":"rgba"}],"type":"ios"}],"parameters":{},"type":"graph"},{"name":"shape","node_position":{"x":-525.749817,"y":117.666656},"parameters":{"edge":0.2,"radius":0.75,"shape":0,"sides":2},"type":"shape"},{"name":"colorize","node_position":{"x":-536.749817,"y":233.55304},"parameters":{"gradient":{"points":[{"a":1,"b":0,"g":0,"pos":0,"r":0},{"a":1,"b":1,"g":1,"pos":1,"r":1}],"type":"Gradient"}},"type":"colorize"}],"parameters":{},"type":"graph"}
+{
+	"connections": [
+		{
+			"from": "shape_2",
+			"from_port": 0,
+			"to": "colorize_2_2",
+			"to_port": 0
+		},
+		{
+			"from": "graph",
+			"from_port": 0,
+			"to": "blend_2_2",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_2_2",
+			"from_port": 0,
+			"to": "blend_2_2",
+			"to_port": 1
+		},
+		{
+			"from": "blend_2_2",
+			"from_port": 0,
+			"to": "colorize_3",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_3",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 3
+		}
+	],
+	"label": "Graph",
+	"name": "39",
+	"node_position": {
+		"x": 0,
+		"y": 0
+	},
+	"nodes": [
+		{
+			"name": "Material",
+			"node_position": {
+				"x": 193,
+				"y": -49
+			},
+			"parameters": {
+				"albedo_color": {
+					"a": 1,
+					"b": 0,
+					"g": 0,
+					"r": 0,
+					"type": "Color"
+				},
+				"ao_light_affect": 1,
+				"depth_scale": 1,
+				"emission_energy": 1,
+				"metallic": 1,
+				"normal_scale": 1,
+				"roughness": 1,
+				"size": 11
+			},
+			"type": "material"
+		},
+		{
+			"name": "shape_2",
+			"node_position": {
+				"x": -533.992065,
+				"y": -0.5
+			},
+			"parameters": {
+				"edge": 1,
+				"radius": 0.25,
+				"shape": 2,
+				"sides": 5
+			},
+			"type": "shape"
+		},
+		{
+			"name": "colorize_2_2",
+			"node_position": {
+				"x": -363.992096,
+				"y": -7
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0.027273,
+							"r": 0
+						},
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0.118182,
+							"r": 1
+						},
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0.143066,
+							"r": 0
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "blend_2_2",
+			"node_position": {
+				"x": -38.492065,
+				"y": 139
+			},
+			"parameters": {
+				"amount": 1,
+				"blend_type": 9
+			},
+			"type": "blend"
+		},
+		{
+			"name": "colorize_3",
+			"node_position": {
+				"x": 106.007935,
+				"y": -288.5
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0,
+							"r": 0
+						},
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 1,
+							"r": 1
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"connections": [
+				{
+					"from": "_2",
+					"from_port": 0,
+					"to": "transform",
+					"to_port": 0
+				},
+				{
+					"from": "transform",
+					"from_port": 0,
+					"to": "_3",
+					"to_port": 0
+				},
+				{
+					"from": "shape",
+					"from_port": 0,
+					"to": "colorize",
+					"to_port": 0
+				},
+				{
+					"from": "colorize",
+					"from_port": 0,
+					"to": "blend",
+					"to_port": 0
+				},
+				{
+					"from": "_3",
+					"from_port": 0,
+					"to": "blend",
+					"to_port": 1
+				},
+				{
+					"from": "shape",
+					"from_port": 0,
+					"to": "colorize_2",
+					"to_port": 0
+				},
+				{
+					"from": "blend",
+					"from_port": 0,
+					"to": "blend_2",
+					"to_port": 0
+				},
+				{
+					"from": "colorize_2",
+					"from_port": 0,
+					"to": "blend_2",
+					"to_port": 1
+				},
+				{
+					"from": "blend_2",
+					"from_port": 0,
+					"to": "gen_outputs",
+					"to_port": 0
+				}
+			],
+			"label": "Runes circle",
+			"name": "graph",
+			"node_position": {
+				"x": -271.03067,
+				"y": -132
+			},
+			"nodes": [
+				{
+					"name": "_2",
+					"node_position": {
+						"x": -400.5,
+						"y": -278.5
+					},
+					"parameters": {
+						"columns": 64,
+						"rows": 8,
+						"thickness": 0.1
+					},
+					"shader_model": {
+						"global": "// Based on Otavio Good's https://www.shadertoy.com/view/MsXSRn\n\nfloat ThickLine(vec2 uv, vec2 posA, vec2 posB, float radiusInv)\n{\n\tvec2 dir = posA - posB;\n\tfloat dirLen = length(dir);\n\tvec2 dirN = normalize(dir);\n\tfloat dotTemp = clamp(dot(uv - posB, dirN), 0.0, dirLen);\n\tvec2 proj = dotTemp * dirN + posB;\n\tfloat d1 = length(uv - proj);\n\tfloat finalGray = clamp(1.0 - d1 * radiusInv, 0.0, 1.0);\n\treturn finalGray;\n}\n\n// makes a rune in the 0..1 uv space. Seed is which rune to draw.\n// passes back gray in x and derivates for lighting in yz\nfloat Rune(vec2 uv, float thickness) {\n\tfloat finalLine = 0.0;\n\tvec2 seed = floor(uv)-0.41;\n\tuv = fract(uv);\n\tfor (int i = 0; i < 4; i++)\t// number of strokes\n\t{\n\t\tvec2 posA = rand2(floor(seed+0.5));\n\t\tvec2 posB = rand2(floor(seed+1.5));\n\t\tseed += 2.0;\n\t\t// expand the range and mod it to get a nicely distributed random number - hopefully. :)\n\t\tposA = fract(posA * 128.0);\n\t\tposB = fract(posB * 128.0);\n\t\t// each rune touches the edge of its box on all 4 sides\n\t\tif (i == 0) posA.y = 0.0;\n\t\tif (i == 1) posA.x = 0.999;\n\t\tif (i == 2) posA.x = 0.0;\n\t\tif (i == 3) posA.y = 0.999;\n\t\t// snap the random line endpoints to a grid 2x3\n\t\tvec2 snaps = vec2(2.0, 3.0);\n\t\tposA = (floor(posA * snaps) + 0.5) / snaps;\t// + 0.5 to center it in a grid cell\n\t\tposB = (floor(posB * snaps) + 0.5) / snaps;\n\t\t//if (distance(posA, posB) < 0.0001) continue;\t// eliminate dots.\n\t\t// Dots (degenerate lines) are not cross-GPU safe without adding 0.001 - divide by 0 error.\n\t\tfinalLine = max(finalLine, ThickLine(uv, posA, posB + 0.001, 1.0/max(0.01, thickness)));\n\t}\n\treturn finalLine;\n}\n\n\n",
+						"inputs": [
+
+						],
+						"instance": "",
+						"name": "Runes",
+						"outputs": [
+							{
+								"f": "Rune(vec2($columns, $rows)*$uv, $thickness)",
+								"type": "f"
+							}
+						],
+						"parameters": [
+							{
+								"default": 0,
+								"label": "",
+								"max": 32,
+								"min": 2,
+								"name": "columns",
+								"step": 1,
+								"type": "float",
+								"widget": "spinbox"
+							},
+							{
+								"default": 0,
+								"label": "",
+								"max": 32,
+								"min": 2,
+								"name": "rows",
+								"step": 1,
+								"type": "float",
+								"widget": "spinbox"
+							},
+							{
+								"default": 0.1,
+								"label": "",
+								"max": 0.3,
+								"min": 0,
+								"name": "thickness",
+								"step": 0.01,
+								"type": "float"
+							}
+						]
+					},
+					"type": "shader"
+				},
+				{
+					"name": "transform",
+					"node_position": {
+						"x": -437.5,
+						"y": -153.5
+					},
+					"parameters": {
+						"repeat": true,
+						"rotate": 0,
+						"scale_x": 8,
+						"scale_y": 1,
+						"translate_x": 0,
+						"translate_y": -0.04
+					},
+					"type": "transform"
+				},
+				{
+					"name": "shape",
+					"node_position": {
+						"x": -156.068481,
+						"y": -262.5
+					},
+					"parameters": {
+						"edge": 0.299221,
+						"radius": 1,
+						"shape": 0,
+						"sides": 3
+					},
+					"type": "shape"
+				},
+				{
+					"name": "colorize",
+					"node_position": {
+						"x": -174.853485,
+						"y": -165.5
+					},
+					"parameters": {
+						"gradient": {
+							"points": [
+								{
+									"a": 1,
+									"b": 0,
+									"g": 0,
+									"pos": 0.1,
+									"r": 0
+								},
+								{
+									"a": 1,
+									"b": 1,
+									"g": 1,
+									"pos": 0.154545,
+									"r": 1
+								},
+								{
+									"a": 1,
+									"b": 1,
+									"g": 1,
+									"pos": 0.545455,
+									"r": 1
+								},
+								{
+									"a": 1,
+									"b": 0,
+									"g": 0,
+									"pos": 0.618182,
+									"r": 0
+								}
+							],
+							"type": "Gradient"
+						}
+					},
+					"type": "colorize"
+				},
+				{
+					"name": "blend",
+					"node_position": {
+						"x": -195.853485,
+						"y": -107.5
+					},
+					"parameters": {
+						"amount": 1,
+						"blend_type": 2
+					},
+					"type": "blend"
+				},
+				{
+					"name": "colorize_2",
+					"node_position": {
+						"x": -167.853485,
+						"y": -26.5
+					},
+					"parameters": {
+						"gradient": {
+							"points": [
+								{
+									"a": 1,
+									"b": 0,
+									"g": 0,
+									"pos": 0.018182,
+									"r": 0
+								},
+								{
+									"a": 1,
+									"b": 1,
+									"g": 1,
+									"pos": 0.081819,
+									"r": 1
+								},
+								{
+									"a": 1,
+									"b": 0,
+									"g": 0,
+									"pos": 0.115793,
+									"r": 0
+								},
+								{
+									"a": 1,
+									"b": 0,
+									"g": 0,
+									"pos": 0.570339,
+									"r": 0
+								},
+								{
+									"a": 1,
+									"b": 1,
+									"g": 1,
+									"pos": 0.633975,
+									"r": 1
+								},
+								{
+									"a": 1,
+									"b": 0,
+									"g": 0,
+									"pos": 0.663637,
+									"r": 0
+								}
+							],
+							"type": "Gradient"
+						}
+					},
+					"type": "colorize"
+				},
+				{
+					"name": "_3",
+					"node_position": {
+						"x": -390.5,
+						"y": 41.5
+					},
+					"parameters": {
+
+					},
+					"shader_model": {
+						"global": "",
+						"inputs": [
+							{
+								"default": "0.0",
+								"label": "",
+								"name": "in",
+								"type": "rgba"
+							}
+						],
+						"instance": "",
+						"name": "DiscMap",
+						"outputs": [
+							{
+								"rgba": "$in(vec2(atan($uv.y-0.5, $uv.x-0.5), 2.0*length($uv-vec2(0.5))))",
+								"type": "rgba"
+							}
+						],
+						"parameters": [
+
+						]
+					},
+					"type": "shader"
+				},
+				{
+					"name": "blend_2",
+					"node_position": {
+						"x": -197.116241,
+						"y": 32.5
+					},
+					"parameters": {
+						"amount": 1,
+						"blend_type": 9
+					},
+					"type": "blend"
+				},
+				{
+					"name": "gen_outputs",
+					"node_position": {
+						"x": 143.931519,
+						"y": -115
+					},
+					"parameters": {
+
+					},
+					"ports": [
+						{
+							"name": "port0",
+							"type": "rgba"
+						}
+					],
+					"type": "ios"
+				}
+			],
+			"parameters": {
+
+			},
+			"type": "graph"
+		},
+		{
+			"name": "shape",
+			"node_position": {
+				"x": -525.749817,
+				"y": 117.666656
+			},
+			"parameters": {
+				"edge": 0.2,
+				"radius": 0.75,
+				"shape": 0,
+				"sides": 2
+			},
+			"type": "shape"
+		},
+		{
+			"name": "colorize",
+			"node_position": {
+				"x": -536.749817,
+				"y": 233.55304
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0,
+							"r": 0
+						},
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 1,
+							"r": 1
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		}
+	],
+	"parameters": {
+
+	},
+	"type": "graph"
+}

--- a/addons/material_maker/examples/planet.ptex
+++ b/addons/material_maker/examples/planet.ptex
@@ -1,1 +1,329 @@
-{"connections":[{"from":"colorize_2","from_port":0,"to":"colorize","to_port":0},{"from":"colorize_2","from_port":0,"to":"colorize_3","to_port":0},{"from":"colorize_3","from_port":0,"to":"Material","to_port":6},{"from":"colorize_2","from_port":0,"to":"Material","to_port":2},{"from":"colorize","from_port":0,"to":"Material","to_port":0},{"from":"colorize_2","from_port":0,"to":"normal_map","to_port":0},{"from":"normal_map","from_port":0,"to":"Material","to_port":4},{"from":"pattern","from_port":0,"to":"colorize_4","to_port":0},{"from":"colorize_4","from_port":0,"to":"blend","to_port":0},{"from":"perlin","from_port":0,"to":"blend","to_port":1},{"from":"blend","from_port":0,"to":"colorize_2","to_port":0}],"label":"Graph","name":"39","node_position":{"x":0,"y":0},"nodes":[{"name":"Material","node_position":{"x":653,"y":157},"parameters":{"albedo_color":{"a":1,"b":1,"g":1,"r":1,"type":"Color"},"ao_light_affect":1,"depth_scale":0.6,"emission_energy":1,"metallic":0.05,"normal_scale":1,"roughness":0.75,"size":11},"type":"material"},{"name":"perlin","node_position":{"x":-334.5,"y":-300.5},"parameters":{"iterations":6,"persistence":0.5,"scale_x":8,"scale_y":8},"type":"perlin"},{"name":"colorize","node_position":{"x":-315.5,"y":-87.5},"parameters":{"gradient":{"points":[{"a":1,"b":1,"g":0.1875,"pos":0.081818,"r":0},{"a":1,"b":0.447917,"g":0.827474,"pos":0.109091,"r":1},{"a":1,"b":0,"g":0.489583,"pos":0.227273,"r":0.107096},{"a":1,"b":0,"g":0.19043,"pos":0.554545,"r":0.338542},{"a":1,"b":0,"g":0.172852,"pos":0.927273,"r":0.307292},{"a":1,"b":1,"g":1,"pos":1,"r":1}],"type":"Gradient"}},"type":"colorize"},{"name":"colorize_2","node_position":{"x":-314.5,"y":-156.5},"parameters":{"gradient":{"points":[{"a":1,"b":0,"g":0,"pos":0.5,"r":0},{"a":1,"b":1,"g":1,"pos":0.836364,"r":1}],"type":"Gradient"}},"type":"colorize"},{"name":"colorize_3","node_position":{"x":-316.5,"y":-21.5},"parameters":{"gradient":{"points":[{"a":1,"b":1,"g":1,"pos":0,"r":1},{"a":1,"b":0,"g":0,"pos":1,"r":0}],"type":"Gradient"}},"type":"colorize"},{"name":"normal_map","node_position":{"x":-20.5,"y":273.5},"parameters":{"amount":0.5,"param0":11,"param1":0.99,"size":4},"type":"normal_map"},{"name":"pattern","node_position":{"x":-343.5,"y":-582.25},"parameters":{"mix":0,"x_scale":4,"x_wave":4,"y_scale":1,"y_wave":0},"type":"pattern"},{"name":"colorize_4","node_position":{"x":-300.5,"y":-473.25},"parameters":{"gradient":{"points":[{"a":1,"b":1,"g":1,"pos":0,"r":1},{"a":1,"b":0.75,"g":0.75,"pos":0.045455,"r":0.75},{"a":1,"b":0,"g":0,"pos":0.363636,"r":0}],"type":"Gradient"}},"type":"colorize"},{"name":"blend","node_position":{"x":-300.5,"y":-399.25},"parameters":{"amount":0.819444,"blend_type":3},"type":"blend"},{"name":"comment","node_position":{"x":-544.5,"y":-395.194458},"parameters":{"size":4},"size":{"x":190,"y":67},"text":"Best viewed on Sphere mesh","type":"comment"}],"parameters":{},"type":"graph"}
+{
+	"connections": [
+		{
+			"from": "colorize_2",
+			"from_port": 0,
+			"to": "colorize",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_2",
+			"from_port": 0,
+			"to": "colorize_3",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_3",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 6
+		},
+		{
+			"from": "colorize_2",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 2
+		},
+		{
+			"from": "colorize",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_2",
+			"from_port": 0,
+			"to": "normal_map",
+			"to_port": 0
+		},
+		{
+			"from": "normal_map",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 4
+		},
+		{
+			"from": "pattern",
+			"from_port": 0,
+			"to": "colorize_4",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_4",
+			"from_port": 0,
+			"to": "blend",
+			"to_port": 0
+		},
+		{
+			"from": "perlin",
+			"from_port": 0,
+			"to": "blend",
+			"to_port": 1
+		},
+		{
+			"from": "blend",
+			"from_port": 0,
+			"to": "colorize_2",
+			"to_port": 0
+		}
+	],
+	"label": "Graph",
+	"name": "39",
+	"node_position": {
+		"x": 0,
+		"y": 0
+	},
+	"nodes": [
+		{
+			"name": "Material",
+			"node_position": {
+				"x": 653,
+				"y": 157
+			},
+			"parameters": {
+				"albedo_color": {
+					"a": 1,
+					"b": 1,
+					"g": 1,
+					"r": 1,
+					"type": "Color"
+				},
+				"ao_light_affect": 1,
+				"depth_scale": 0.6,
+				"emission_energy": 1,
+				"metallic": 0.05,
+				"normal_scale": 1,
+				"roughness": 0.75,
+				"size": 11
+			},
+			"type": "material"
+		},
+		{
+			"name": "perlin",
+			"node_position": {
+				"x": -334.5,
+				"y": -300.5
+			},
+			"parameters": {
+				"iterations": 6,
+				"persistence": 0.5,
+				"scale_x": 8,
+				"scale_y": 8
+			},
+			"type": "perlin"
+		},
+		{
+			"name": "colorize",
+			"node_position": {
+				"x": -315.5,
+				"y": -87.5
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 1,
+							"g": 0.1875,
+							"pos": 0.081818,
+							"r": 0
+						},
+						{
+							"a": 1,
+							"b": 0.447917,
+							"g": 0.827474,
+							"pos": 0.109091,
+							"r": 1
+						},
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0.489583,
+							"pos": 0.227273,
+							"r": 0.107096
+						},
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0.19043,
+							"pos": 0.554545,
+							"r": 0.338542
+						},
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0.172852,
+							"pos": 0.927273,
+							"r": 0.307292
+						},
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 1,
+							"r": 1
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "colorize_2",
+			"node_position": {
+				"x": -314.5,
+				"y": -156.5
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0.5,
+							"r": 0
+						},
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0.836364,
+							"r": 1
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "colorize_3",
+			"node_position": {
+				"x": -316.5,
+				"y": -21.5
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0,
+							"r": 1
+						},
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 1,
+							"r": 0
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "normal_map",
+			"node_position": {
+				"x": -20.5,
+				"y": 273.5
+			},
+			"parameters": {
+				"amount": 0.5,
+				"param0": 11,
+				"param1": 11,
+				"param2": 1,
+				"size": 4
+			},
+			"type": "normal_map"
+		},
+		{
+			"name": "pattern",
+			"node_position": {
+				"x": -343.5,
+				"y": -582.25
+			},
+			"parameters": {
+				"mix": 0,
+				"x_scale": 4,
+				"x_wave": 4,
+				"y_scale": 1,
+				"y_wave": 0
+			},
+			"type": "pattern"
+		},
+		{
+			"name": "colorize_4",
+			"node_position": {
+				"x": -300.5,
+				"y": -473.25
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0,
+							"r": 1
+						},
+						{
+							"a": 1,
+							"b": 0.75,
+							"g": 0.75,
+							"pos": 0.045455,
+							"r": 0.75
+						},
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0.363636,
+							"r": 0
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "blend",
+			"node_position": {
+				"x": -300.5,
+				"y": -399.25
+			},
+			"parameters": {
+				"amount": 0.819444,
+				"blend_type": 3
+			},
+			"type": "blend"
+		},
+		{
+			"name": "comment",
+			"node_position": {
+				"x": -544.5,
+				"y": -395.194458
+			},
+			"parameters": {
+				"size": 4
+			},
+			"size": {
+				"x": 190,
+				"y": 67
+			},
+			"text": "Best viewed on Sphere mesh",
+			"type": "comment"
+		}
+	],
+	"parameters": {
+
+	},
+	"type": "graph"
+}

--- a/addons/material_maker/examples/radiation.ptex
+++ b/addons/material_maker/examples/radiation.ptex
@@ -1,1 +1,232 @@
-{"connections":[{"from":"shape_2","from_port":0,"to":"blend_1","to_port":0},{"from":"shape_1","from_port":0,"to":"blend_1","to_port":1},{"from":"blend_0","from_port":0,"to":"blend_2","to_port":0},{"from":"shape_3","from_port":0,"to":"blend_2","to_port":1},{"from":"blend_2","from_port":0,"to":"colorize_0","to_port":0},{"from":"colorize_0","from_port":0,"to":"Material","to_port":0},{"from":"transform_0","from_port":0,"to":"blend_0","to_port":1},{"from":"blend_1","from_port":0,"to":"blend_0","to_port":0},{"from":"shape_0","from_port":0,"to":"transform_0","to_port":0}],"label":"Graph","name":"535","node_position":{"x":0,"y":0},"nodes":[{"name":"shape_3","node_position":{"x":-35,"y":36},"parameters":{"edge":0.05,"radius":0.18,"shape":0,"sides":3},"type":"shape"},{"name":"shape_0","node_position":{"x":-407,"y":19},"parameters":{"edge":0.02,"radius":0.5,"shape":4,"sides":3},"type":"shape"},{"name":"shape_1","node_position":{"x":-412,"y":-117},"parameters":{"edge":0.02,"radius":0.87,"shape":0,"sides":3},"type":"shape"},{"name":"shape_2","node_position":{"x":-411,"y":-218},"parameters":{"edge":0.02,"radius":0.34,"shape":0,"sides":3},"type":"shape"},{"name":"blend_1","node_position":{"x":-236,"y":-159},"parameters":{"amount":1,"blend_type":11},"type":"blend"},{"name":"Material","node_position":{"x":528,"y":-57},"parameters":{"albedo_color":{"a":1,"b":1,"g":1,"r":1,"type":"Color"},"ao_light_affect":1,"depth_scale":1,"emission_energy":1,"metallic":1,"normal_scale":1,"resolution":1,"roughness":1,"size":11},"type":"material"},{"name":"blend_0","node_position":{"x":-40,"y":-82},"parameters":{"amount":1,"blend_type":2},"type":"blend"},{"name":"transform_0","node_position":{"x":-245.657654,"y":-16.611115},"parameters":{"repeat":true,"rotate":30,"scale_x":1,"scale_y":1,"translate_x":0,"translate_y":0},"type":"transform"},{"name":"blend_2","node_position":{"x":145,"y":36},"parameters":{"amount":1,"blend_type":3},"type":"blend"},{"name":"colorize_0","node_position":{"x":292.081177,"y":-103.5},"parameters":{"gradient":{"points":[{"a":1,"b":0,"g":0.820313,"pos":0,"r":0.9375},{"a":1,"b":0,"g":0,"pos":1,"r":0}],"type":"Gradient"}},"type":"colorize"}],"parameters":{},"type":"graph"}
+{
+	"connections": [
+		{
+			"from": "shape_2",
+			"from_port": 0,
+			"to": "blend_1",
+			"to_port": 0
+		},
+		{
+			"from": "shape_1",
+			"from_port": 0,
+			"to": "blend_1",
+			"to_port": 1
+		},
+		{
+			"from": "blend_0",
+			"from_port": 0,
+			"to": "blend_2",
+			"to_port": 0
+		},
+		{
+			"from": "shape_3",
+			"from_port": 0,
+			"to": "blend_2",
+			"to_port": 1
+		},
+		{
+			"from": "blend_2",
+			"from_port": 0,
+			"to": "colorize_0",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_0",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 0
+		},
+		{
+			"from": "transform_0",
+			"from_port": 0,
+			"to": "blend_0",
+			"to_port": 1
+		},
+		{
+			"from": "blend_1",
+			"from_port": 0,
+			"to": "blend_0",
+			"to_port": 0
+		},
+		{
+			"from": "shape_0",
+			"from_port": 0,
+			"to": "transform_0",
+			"to_port": 0
+		}
+	],
+	"label": "Graph",
+	"name": "535",
+	"node_position": {
+		"x": 0,
+		"y": 0
+	},
+	"nodes": [
+		{
+			"name": "shape_3",
+			"node_position": {
+				"x": -35,
+				"y": 36
+			},
+			"parameters": {
+				"edge": 0.05,
+				"radius": 0.18,
+				"shape": 0,
+				"sides": 3
+			},
+			"type": "shape"
+		},
+		{
+			"name": "shape_0",
+			"node_position": {
+				"x": -407,
+				"y": 19
+			},
+			"parameters": {
+				"edge": 0.02,
+				"radius": 0.5,
+				"shape": 4,
+				"sides": 3
+			},
+			"type": "shape"
+		},
+		{
+			"name": "shape_1",
+			"node_position": {
+				"x": -412,
+				"y": -117
+			},
+			"parameters": {
+				"edge": 0.02,
+				"radius": 0.87,
+				"shape": 0,
+				"sides": 3
+			},
+			"type": "shape"
+		},
+		{
+			"name": "shape_2",
+			"node_position": {
+				"x": -411,
+				"y": -218
+			},
+			"parameters": {
+				"edge": 0.02,
+				"radius": 0.34,
+				"shape": 0,
+				"sides": 3
+			},
+			"type": "shape"
+		},
+		{
+			"name": "blend_1",
+			"node_position": {
+				"x": -236,
+				"y": -159
+			},
+			"parameters": {
+				"amount": 1,
+				"blend_type": 11
+			},
+			"type": "blend"
+		},
+		{
+			"name": "Material",
+			"node_position": {
+				"x": 528,
+				"y": -57
+			},
+			"parameters": {
+				"albedo_color": {
+					"a": 1,
+					"b": 1,
+					"g": 1,
+					"r": 1,
+					"type": "Color"
+				},
+				"ao_light_affect": 1,
+				"depth_scale": 1,
+				"emission_energy": 1,
+				"metallic": 1,
+				"normal_scale": 1,
+				"resolution": 1,
+				"roughness": 1,
+				"size": 11
+			},
+			"type": "material"
+		},
+		{
+			"name": "blend_0",
+			"node_position": {
+				"x": -40,
+				"y": -82
+			},
+			"parameters": {
+				"amount": 1,
+				"blend_type": 2
+			},
+			"type": "blend"
+		},
+		{
+			"name": "transform_0",
+			"node_position": {
+				"x": -245.657654,
+				"y": -16.611115
+			},
+			"parameters": {
+				"repeat": true,
+				"rotate": 30,
+				"scale_x": 1,
+				"scale_y": 1,
+				"translate_x": 0,
+				"translate_y": 0
+			},
+			"type": "transform"
+		},
+		{
+			"name": "blend_2",
+			"node_position": {
+				"x": 145,
+				"y": 36
+			},
+			"parameters": {
+				"amount": 1,
+				"blend_type": 3
+			},
+			"type": "blend"
+		},
+		{
+			"name": "colorize_0",
+			"node_position": {
+				"x": 292.081177,
+				"y": -103.5
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0.820313,
+							"pos": 0,
+							"r": 0.9375
+						},
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 1,
+							"r": 0
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		}
+	],
+	"parameters": {
+
+	},
+	"type": "graph"
+}

--- a/addons/material_maker/examples/rock.ptex
+++ b/addons/material_maker/examples/rock.ptex
@@ -1,1 +1,316 @@
-{"connections":[{"from":"voronoi_0","from_port":0,"to":"blend_0","to_port":0},{"from":"voronoi_0","from_port":1,"to":"blend_0","to_port":1},{"from":"perlin_0","from_port":0,"to":"blend_0","to_port":2},{"from":"blend_0","from_port":0,"to":"colorize_0","to_port":0},{"from":"colorize_0","from_port":0,"to":"Material","to_port":0},{"from":"normal_map_0","from_port":0,"to":"Material","to_port":4},{"from":"perlin_0","from_port":0,"to":"colorize_1","to_port":0},{"from":"colorize_1","from_port":0,"to":"Material","to_port":1},{"from":"perlin_0","from_port":0,"to":"colorize_2","to_port":0},{"from":"colorize_2","from_port":0,"to":"Material","to_port":2},{"from":"perlin_1","from_port":0,"to":"warp_0","to_port":1},{"from":"voronoi_1","from_port":1,"to":"warp_0","to_port":0},{"from":"warp_0","from_port":0,"to":"normal_map_0","to_port":0}],"label":"Graph","name":"553","node_position":{"x":0,"y":0},"nodes":[{"name":"normal_map_0","node_position":{"x":583,"y":463},"parameters":{"amount":0.5,"param0":11,"param1":0.99,"size":2},"type":"normal_map"},{"name":"colorize_1","node_position":{"x":533,"y":343},"parameters":{"gradient":{"points":[{"a":1,"b":0,"g":0,"pos":0,"r":0},{"a":1,"b":0.260417,"g":0.260417,"pos":1,"r":0.260417}],"type":"Gradient"}},"type":"colorize"},{"name":"colorize_0","node_position":{"x":530,"y":171},"parameters":{"gradient":{"points":[{"a":1,"b":0.391927,"g":0.523519,"pos":0,"r":0.583333},{"a":1,"b":0.240885,"g":0.276693,"pos":0.345455,"r":0.3125},{"a":1,"b":0.391927,"g":0.523519,"pos":0.645455,"r":0.583333},{"a":1,"b":0.240885,"g":0.276693,"pos":0.945455,"r":0.3125}],"type":"Gradient"}},"type":"colorize"},{"name":"colorize_2","node_position":{"x":526,"y":258},"parameters":{"gradient":{"points":[{"a":1,"b":0.364583,"g":0.364583,"pos":0,"r":0.364583},{"a":1,"b":1,"g":1,"pos":1,"r":1}],"type":"Gradient"}},"type":"colorize"},{"name":"perlin_0","node_position":{"x":105,"y":305},"parameters":{"iterations":6,"persistence":0.85,"scale_x":4,"scale_y":4},"type":"perlin"},{"name":"perlin_1","node_position":{"x":102,"y":166},"parameters":{"iterations":3,"persistence":0.65,"scale_x":4,"scale_y":4},"type":"perlin"},{"name":"voronoi_1","node_position":{"x":115,"y":63},"parameters":{"intensity":0.85,"randomness":1,"scale_x":4,"scale_y":4},"type":"voronoi"},{"name":"Material","node_position":{"x":768,"y":239},"parameters":{"albedo_color":{"a":1,"b":1,"g":1,"r":1,"type":"Color"},"ao_light_affect":1,"depth_scale":1,"emission_energy":1,"metallic":1,"normal_scale":1,"resolution":1,"roughness":1,"size":11},"type":"material"},{"name":"warp_0","node_position":{"x":317,"y":139},"parameters":{"amount":0.3,"eps":0.045,"epsilon":0},"type":"warp"},{"name":"voronoi_0","node_position":{"x":117,"y":448},"parameters":{"intensity":1,"randomness":1,"scale_x":4,"scale_y":4},"type":"voronoi"},{"name":"blend_0","node_position":{"x":327,"y":411},"parameters":{"amount":0.5,"blend_type":0},"type":"blend"}],"parameters":{},"type":"graph"}
+{
+	"connections": [
+		{
+			"from": "voronoi_0",
+			"from_port": 0,
+			"to": "blend_0",
+			"to_port": 0
+		},
+		{
+			"from": "voronoi_0",
+			"from_port": 1,
+			"to": "blend_0",
+			"to_port": 1
+		},
+		{
+			"from": "perlin_0",
+			"from_port": 0,
+			"to": "blend_0",
+			"to_port": 2
+		},
+		{
+			"from": "blend_0",
+			"from_port": 0,
+			"to": "colorize_0",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_0",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 0
+		},
+		{
+			"from": "normal_map_0",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 4
+		},
+		{
+			"from": "perlin_0",
+			"from_port": 0,
+			"to": "colorize_1",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_1",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 1
+		},
+		{
+			"from": "perlin_0",
+			"from_port": 0,
+			"to": "colorize_2",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_2",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 2
+		},
+		{
+			"from": "perlin_1",
+			"from_port": 0,
+			"to": "warp_0",
+			"to_port": 1
+		},
+		{
+			"from": "voronoi_1",
+			"from_port": 1,
+			"to": "warp_0",
+			"to_port": 0
+		},
+		{
+			"from": "warp_0",
+			"from_port": 0,
+			"to": "normal_map_0",
+			"to_port": 0
+		}
+	],
+	"label": "Graph",
+	"name": "553",
+	"node_position": {
+		"x": 0,
+		"y": 0
+	},
+	"nodes": [
+		{
+			"name": "normal_map_0",
+			"node_position": {
+				"x": 583,
+				"y": 463
+			},
+			"parameters": {
+				"amount": 0.5,
+				"param0": 11,
+				"param1": 11,
+				"param2": 1,
+				"size": 2
+			},
+			"type": "normal_map"
+		},
+		{
+			"name": "colorize_1",
+			"node_position": {
+				"x": 533,
+				"y": 343
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0,
+							"r": 0
+						},
+						{
+							"a": 1,
+							"b": 0.260417,
+							"g": 0.260417,
+							"pos": 1,
+							"r": 0.260417
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "colorize_0",
+			"node_position": {
+				"x": 530,
+				"y": 171
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0.391927,
+							"g": 0.523519,
+							"pos": 0,
+							"r": 0.583333
+						},
+						{
+							"a": 1,
+							"b": 0.240885,
+							"g": 0.276693,
+							"pos": 0.345455,
+							"r": 0.3125
+						},
+						{
+							"a": 1,
+							"b": 0.391927,
+							"g": 0.523519,
+							"pos": 0.645455,
+							"r": 0.583333
+						},
+						{
+							"a": 1,
+							"b": 0.240885,
+							"g": 0.276693,
+							"pos": 0.945455,
+							"r": 0.3125
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "colorize_2",
+			"node_position": {
+				"x": 526,
+				"y": 258
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0.364583,
+							"g": 0.364583,
+							"pos": 0,
+							"r": 0.364583
+						},
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 1,
+							"r": 1
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "perlin_0",
+			"node_position": {
+				"x": 105,
+				"y": 305
+			},
+			"parameters": {
+				"iterations": 6,
+				"persistence": 0.85,
+				"scale_x": 4,
+				"scale_y": 4
+			},
+			"type": "perlin"
+		},
+		{
+			"name": "perlin_1",
+			"node_position": {
+				"x": 102,
+				"y": 166
+			},
+			"parameters": {
+				"iterations": 3,
+				"persistence": 0.65,
+				"scale_x": 4,
+				"scale_y": 4
+			},
+			"type": "perlin"
+		},
+		{
+			"name": "voronoi_1",
+			"node_position": {
+				"x": 115,
+				"y": 63
+			},
+			"parameters": {
+				"intensity": 0.85,
+				"randomness": 1,
+				"scale_x": 4,
+				"scale_y": 4
+			},
+			"type": "voronoi"
+		},
+		{
+			"name": "Material",
+			"node_position": {
+				"x": 768,
+				"y": 239
+			},
+			"parameters": {
+				"albedo_color": {
+					"a": 1,
+					"b": 1,
+					"g": 1,
+					"r": 1,
+					"type": "Color"
+				},
+				"ao_light_affect": 1,
+				"depth_scale": 1,
+				"emission_energy": 1,
+				"metallic": 1,
+				"normal_scale": 1,
+				"resolution": 1,
+				"roughness": 1,
+				"size": 11
+			},
+			"type": "material"
+		},
+		{
+			"name": "warp_0",
+			"node_position": {
+				"x": 317,
+				"y": 139
+			},
+			"parameters": {
+				"amount": 0.3,
+				"eps": 0.045,
+				"epsilon": 0
+			},
+			"type": "warp"
+		},
+		{
+			"name": "voronoi_0",
+			"node_position": {
+				"x": 117,
+				"y": 448
+			},
+			"parameters": {
+				"intensity": 1,
+				"randomness": 1,
+				"scale_x": 4,
+				"scale_y": 4
+			},
+			"type": "voronoi"
+		},
+		{
+			"name": "blend_0",
+			"node_position": {
+				"x": 327,
+				"y": 411
+			},
+			"parameters": {
+				"amount": 0.5,
+				"blend_type": 0
+			},
+			"type": "blend"
+		}
+	],
+	"parameters": {
+
+	},
+	"type": "graph"
+}

--- a/addons/material_maker/examples/rusted_metal.ptex
+++ b/addons/material_maker/examples/rusted_metal.ptex
@@ -1,1 +1,360 @@
-{"connections":[{"from":"perlin_0","from_port":0,"to":"colorize_0","to_port":0},{"from":"perlin_1","from_port":0,"to":"colorize_1","to_port":0},{"from":"colorize_2","from_port":0,"to":"blend_0","to_port":0},{"from":"colorize_1","from_port":0,"to":"blend_0","to_port":1},{"from":"perlin_2","from_port":0,"to":"colorize_3","to_port":0},{"from":"colorize_3","from_port":0,"to":"blend_0","to_port":2},{"from":"colorize_0","from_port":0,"to":"blend_1","to_port":1},{"from":"blend_0","from_port":0,"to":"Material","to_port":0},{"from":"perlin_1","from_port":0,"to":"colorize_2","to_port":0},{"from":"colorize_3","from_port":0,"to":"Material","to_port":1},{"from":"blend_1","from_port":0,"to":"Material","to_port":2},{"from":"colorize_4","from_port":0,"to":"blend_1","to_port":0},{"from":"colorize_3","from_port":0,"to":"colorize_4","to_port":0},{"from":"colorize_3","from_port":0,"to":"combine_0","to_port":0},{"from":"blend_1","from_port":0,"to":"combine_0","to_port":1}],"label":"Graph","name":"431","node_position":{"x":0,"y":0},"nodes":[{"name":"perlin_0","node_position":{"x":86,"y":301},"parameters":{"iterations":8,"persistence":0.7,"scale_x":4,"scale_y":4},"type":"perlin"},{"name":"perlin_1","node_position":{"x":86,"y":147},"parameters":{"iterations":8,"persistence":0.8,"scale_x":4,"scale_y":4},"type":"perlin"},{"name":"perlin_2","node_position":{"x":89,"y":-6},"parameters":{"iterations":8,"persistence":0.9,"scale_x":4,"scale_y":4},"type":"perlin"},{"name":"colorize_2","node_position":{"x":365,"y":-41},"parameters":{"gradient":{"points":[{"a":1,"b":0.335938,"g":0.335938,"pos":0,"r":0.335938},{"a":1,"b":0.695313,"g":0.695313,"pos":1,"r":0.695313}],"type":"Gradient"}},"type":"colorize"},{"name":"colorize_0","node_position":{"x":363,"y":337},"parameters":{"gradient":{"points":[{"a":1,"b":0.354545,"g":0.354545,"pos":0,"r":0.354545},{"a":1,"b":0.745455,"g":0.745455,"pos":1,"r":0.745455}],"type":"Gradient"}},"type":"colorize"},{"name":"colorize_3","node_position":{"x":371,"y":47},"parameters":{"gradient":{"points":[{"a":1,"b":0,"g":0,"pos":0.445455,"r":0},{"a":1,"b":1,"g":1,"pos":0.445455,"r":1}],"type":"Gradient"}},"type":"colorize"},{"name":"colorize_1","node_position":{"x":371,"y":214},"parameters":{"gradient":{"points":[{"a":1,"b":0,"g":0.091146,"pos":0,"r":0.208333},{"a":1,"b":0,"g":0.1875,"pos":1,"r":1}],"type":"Gradient"}},"type":"colorize"},{"name":"colorize_4","node_position":{"x":480,"y":141},"parameters":{"gradient":{"points":[{"a":1,"b":1,"g":1,"pos":0,"r":1},{"a":1,"b":0,"g":0,"pos":1,"r":0}],"type":"Gradient"}},"type":"colorize"},{"name":"Material","node_position":{"x":837,"y":123},"parameters":{"albedo_color":{"a":1,"b":1,"g":1,"r":1,"type":"Color"},"ao_light_affect":1,"depth_scale":1,"emission_energy":1,"metallic":1,"normal_scale":1,"resolution":1,"roughness":1,"size":11},"type":"material"},{"name":"blend_1","node_position":{"x":566,"y":253},"parameters":{"amount":0.5,"blend_type":4},"type":"blend"},{"name":"blend_0","node_position":{"x":562,"y":-23},"parameters":{"amount":0.800781,"blend_type":0},"type":"blend"},{"name":"combine_0","node_position":{"x":849,"y":-6},"parameters":{"color":{"a":1,"b":1,"g":1,"r":1,"type":"Color"},"name":0},"type":"combine"}],"parameters":{},"type":"graph"}
+{
+	"connections": [
+		{
+			"from": "perlin_0",
+			"from_port": 0,
+			"to": "colorize_0",
+			"to_port": 0
+		},
+		{
+			"from": "perlin_1",
+			"from_port": 0,
+			"to": "colorize_1",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_2",
+			"from_port": 0,
+			"to": "blend_0",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_1",
+			"from_port": 0,
+			"to": "blend_0",
+			"to_port": 1
+		},
+		{
+			"from": "perlin_2",
+			"from_port": 0,
+			"to": "colorize_3",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_3",
+			"from_port": 0,
+			"to": "blend_0",
+			"to_port": 2
+		},
+		{
+			"from": "colorize_0",
+			"from_port": 0,
+			"to": "blend_1",
+			"to_port": 1
+		},
+		{
+			"from": "blend_0",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 0
+		},
+		{
+			"from": "perlin_1",
+			"from_port": 0,
+			"to": "colorize_2",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_3",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 1
+		},
+		{
+			"from": "blend_1",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 2
+		},
+		{
+			"from": "colorize_4",
+			"from_port": 0,
+			"to": "blend_1",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_3",
+			"from_port": 0,
+			"to": "colorize_4",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_3",
+			"from_port": 0,
+			"to": "combine_0",
+			"to_port": 0
+		},
+		{
+			"from": "blend_1",
+			"from_port": 0,
+			"to": "combine_0",
+			"to_port": 1
+		}
+	],
+	"label": "Graph",
+	"name": "431",
+	"node_position": {
+		"x": 0,
+		"y": 0
+	},
+	"nodes": [
+		{
+			"name": "perlin_0",
+			"node_position": {
+				"x": 86,
+				"y": 301
+			},
+			"parameters": {
+				"iterations": 8,
+				"persistence": 0.7,
+				"scale_x": 4,
+				"scale_y": 4
+			},
+			"type": "perlin"
+		},
+		{
+			"name": "perlin_1",
+			"node_position": {
+				"x": 86,
+				"y": 147
+			},
+			"parameters": {
+				"iterations": 8,
+				"persistence": 0.8,
+				"scale_x": 4,
+				"scale_y": 4
+			},
+			"type": "perlin"
+		},
+		{
+			"name": "perlin_2",
+			"node_position": {
+				"x": 89,
+				"y": -6
+			},
+			"parameters": {
+				"iterations": 8,
+				"persistence": 0.9,
+				"scale_x": 4,
+				"scale_y": 4
+			},
+			"type": "perlin"
+		},
+		{
+			"name": "colorize_2",
+			"node_position": {
+				"x": 365,
+				"y": -41
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0.335938,
+							"g": 0.335938,
+							"pos": 0,
+							"r": 0.335938
+						},
+						{
+							"a": 1,
+							"b": 0.695313,
+							"g": 0.695313,
+							"pos": 1,
+							"r": 0.695313
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "colorize_0",
+			"node_position": {
+				"x": 363,
+				"y": 337
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0.354545,
+							"g": 0.354545,
+							"pos": 0,
+							"r": 0.354545
+						},
+						{
+							"a": 1,
+							"b": 0.745455,
+							"g": 0.745455,
+							"pos": 1,
+							"r": 0.745455
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "colorize_3",
+			"node_position": {
+				"x": 371,
+				"y": 47
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0.445455,
+							"r": 0
+						},
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0.445455,
+							"r": 1
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "colorize_1",
+			"node_position": {
+				"x": 371,
+				"y": 214
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0.091146,
+							"pos": 0,
+							"r": 0.208333
+						},
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0.1875,
+							"pos": 1,
+							"r": 1
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "colorize_4",
+			"node_position": {
+				"x": 480,
+				"y": 141
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0,
+							"r": 1
+						},
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 1,
+							"r": 0
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "Material",
+			"node_position": {
+				"x": 837,
+				"y": 123
+			},
+			"parameters": {
+				"albedo_color": {
+					"a": 1,
+					"b": 1,
+					"g": 1,
+					"r": 1,
+					"type": "Color"
+				},
+				"ao_light_affect": 1,
+				"depth_scale": 1,
+				"emission_energy": 1,
+				"metallic": 1,
+				"normal_scale": 1,
+				"resolution": 1,
+				"roughness": 1,
+				"size": 11
+			},
+			"type": "material"
+		},
+		{
+			"name": "blend_1",
+			"node_position": {
+				"x": 566,
+				"y": 253
+			},
+			"parameters": {
+				"amount": 0.5,
+				"blend_type": 4
+			},
+			"type": "blend"
+		},
+		{
+			"name": "blend_0",
+			"node_position": {
+				"x": 562,
+				"y": -23
+			},
+			"parameters": {
+				"amount": 0.800781,
+				"blend_type": 0
+			},
+			"type": "blend"
+		},
+		{
+			"name": "combine_0",
+			"node_position": {
+				"x": 849,
+				"y": -6
+			},
+			"parameters": {
+				"color": {
+					"a": 1,
+					"b": 1,
+					"g": 1,
+					"r": 1,
+					"type": "Color"
+				},
+				"name": 0
+			},
+			"type": "combine"
+		}
+	],
+	"parameters": {
+
+	},
+	"type": "graph"
+}

--- a/addons/material_maker/examples/stone_wall.ptex
+++ b/addons/material_maker/examples/stone_wall.ptex
@@ -1,1 +1,580 @@
-{"connections":[{"from":"Warp","from_port":0,"to":"colorize_2","to_port":0},{"from":"colorize_2","from_port":0,"to":"blend_0","to_port":2},{"from":"colorize_0","from_port":0,"to":"blend_0","to_port":1},{"from":"blend_1","from_port":0,"to":"colorize_1","to_port":0},{"from":"Warp","from_port":0,"to":"blend_2","to_port":0},{"from":"Perlin","from_port":0,"to":"blend_2","to_port":1},{"from":"blend_2","from_port":0,"to":"colorize_6","to_port":0},{"from":"Perlin","from_port":0,"to":"blend_1","to_port":0},{"from":"Perlin","from_port":0,"to":"colorize_0","to_port":0},{"from":"perlin_0","from_port":0,"to":"Warp","to_port":1},{"from":"uniform_0","from_port":0,"to":"Material","to_port":1},{"from":"blend_2","from_port":0,"to":"colorize_4","to_port":0},{"from":"voronoi_0","from_port":1,"to":"colorize_5","to_port":0},{"from":"blend_0","from_port":0,"to":"Material","to_port":0},{"from":"colorize_2","from_port":0,"to":"colorize_7","to_port":0},{"from":"colorize_7","from_port":0,"to":"Material","to_port":2},{"from":"Bricks","from_port":0,"to":"Warp","to_port":0},{"from":"Bricks","from_port":1,"to":"blend_1","to_port":1},{"from":"colorize_1","from_port":0,"to":"blend_0","to_port":0},{"from":"colorize_4","from_port":0,"to":"Material","to_port":5},{"from":"uniform_0","from_port":0,"to":"combine_0","to_port":0},{"from":"colorize_7","from_port":0,"to":"combine_0","to_port":1},{"from":"normal_map_0","from_port":0,"to":"Material","to_port":4},{"from":"colorize_6","from_port":0,"to":"Material","to_port":6},{"from":"blend_2","from_port":0,"to":"normal_map_0","to_port":0}],"label":"Graph","name":"446","node_position":{"x":0,"y":0},"nodes":[{"name":"voronoi_0","node_position":{"x":-288,"y":-107},"parameters":{"intensity":1,"randomness":1,"scale_x":8,"scale_y":8},"type":"voronoi"},{"name":"colorize_5","node_position":{"x":-104,"y":-87},"parameters":{"gradient":{"points":[{"a":1,"b":0,"g":0,"pos":0.027273,"r":0},{"a":1,"b":1,"g":1,"pos":0.1,"r":1}],"type":"Gradient"}},"type":"colorize"},{"name":"colorize_0","node_position":{"x":560.943665,"y":50},"parameters":{"gradient":{"points":[{"a":1,"b":0,"g":0,"pos":0,"r":0},{"a":1,"b":1,"g":1,"pos":1,"r":1}],"type":"Gradient"}},"type":"colorize"},{"name":"perlin_0","node_position":{"x":13,"y":218},"parameters":{"iterations":4,"persistence":0.75,"scale_x":4,"scale_y":4},"type":"perlin"},{"name":"colorize_1","node_position":{"x":393.943665,"y":-124},"parameters":{"gradient":{"points":[{"a":1,"b":0.557292,"g":0.557292,"pos":0,"r":0.557292},{"a":1,"b":0.180664,"g":0.22934,"pos":0.145455,"r":0.234375},{"a":1,"b":0.585504,"g":0.672174,"pos":0.345455,"r":0.739583},{"a":1,"b":0.144423,"g":0.184147,"pos":0.545455,"r":0.229167},{"a":1,"b":0.447537,"g":0.553291,"pos":0.745455,"r":0.588542},{"a":1,"b":0.199002,"g":0.342478,"pos":1,"r":0.682292}],"type":"Gradient"}},"type":"colorize"},{"name":"blend_1","node_position":{"x":286,"y":252},"parameters":{"amount":0.5,"blend_type":6},"type":"blend"},{"name":"Perlin","node_position":{"x":74,"y":-255},"parameters":{"iterations":8,"persistence":0.8,"scale_x":4,"scale_y":4},"type":"perlin"},{"name":"colorize_2","node_position":{"x":535.943665,"y":163},"parameters":{"gradient":{"points":[{"a":1,"b":0,"g":0,"pos":0,"r":0},{"a":1,"b":1,"g":1,"pos":0.045455,"r":1}],"type":"Gradient"}},"type":"colorize"},{"name":"colorize_6","node_position":{"x":732,"y":195},"parameters":{"gradient":{"points":[{"a":1,"b":1,"g":1,"pos":0,"r":1},{"a":1,"b":0,"g":0,"pos":1,"r":0}],"type":"Gradient"}},"type":"colorize"},{"name":"blend_0","node_position":{"x":763.943726,"y":13},"parameters":{"amount":1,"blend_type":0},"type":"blend"},{"name":"uniform_0","node_position":{"x":931,"y":95},"parameters":{"color":{"a":1,"b":0,"g":0,"r":0,"type":"Color"}},"type":"uniform"},{"name":"Material","node_position":{"x":1161,"y":114},"parameters":{"albedo_color":{"a":1,"b":1,"g":1,"r":1,"type":"Color"},"ao_light_affect":1,"depth_scale":0.2,"emission_energy":1,"metallic":1,"normal_scale":1,"resolution":1,"roughness":1,"size":11},"type":"material"},{"name":"combine_0","node_position":{"x":1119.687012,"y":-22.258774},"parameters":{"color":{"a":1,"b":1,"g":1,"r":1,"type":"Color"},"name":0},"type":"combine"},{"name":"colorize_7","node_position":{"x":915.356934,"y":149},"parameters":{"gradient":{"points":[{"a":1,"b":1,"g":1,"pos":0,"r":1},{"a":1,"b":0.479167,"g":0.479167,"pos":0.136364,"r":0.479167}],"type":"Gradient"}},"type":"colorize"},{"name":"colorize_4","node_position":{"x":787,"y":296},"parameters":{"gradient":{"points":[{"a":1,"b":0.15625,"g":0.15625,"pos":0,"r":0.15625},{"a":1,"b":1,"g":1,"pos":0.454545,"r":1}],"type":"Gradient"}},"type":"colorize"},{"name":"normal_map_0","node_position":{"x":926.587036,"y":211.716217},"parameters":{"amount":0.5,"param0":11,"param1":0.79,"size":4},"type":"normal_map"},{"name":"Warp","node_position":{"x":298,"y":88.75},"parameters":{"amount":0.05,"eps":0.05,"epsilon":0},"type":"warp"},{"name":"blend_2","node_position":{"x":537,"y":264},"parameters":{"amount":0.5,"blend_type":0},"type":"blend"},{"name":"Bricks","node_position":{"x":-56,"y":-6},"parameters":{"bevel":0.15,"columns":3,"mortar":0.05,"pattern":0,"repeat":1,"row_offset":0.5,"rows":6},"type":"bricks"}],"parameters":{},"type":"graph"}
+{
+	"connections": [
+		{
+			"from": "Warp",
+			"from_port": 0,
+			"to": "colorize_2",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_2",
+			"from_port": 0,
+			"to": "blend_0",
+			"to_port": 2
+		},
+		{
+			"from": "colorize_0",
+			"from_port": 0,
+			"to": "blend_0",
+			"to_port": 1
+		},
+		{
+			"from": "blend_1",
+			"from_port": 0,
+			"to": "colorize_1",
+			"to_port": 0
+		},
+		{
+			"from": "Warp",
+			"from_port": 0,
+			"to": "blend_2",
+			"to_port": 0
+		},
+		{
+			"from": "Perlin",
+			"from_port": 0,
+			"to": "blend_2",
+			"to_port": 1
+		},
+		{
+			"from": "blend_2",
+			"from_port": 0,
+			"to": "colorize_6",
+			"to_port": 0
+		},
+		{
+			"from": "Perlin",
+			"from_port": 0,
+			"to": "blend_1",
+			"to_port": 0
+		},
+		{
+			"from": "Perlin",
+			"from_port": 0,
+			"to": "colorize_0",
+			"to_port": 0
+		},
+		{
+			"from": "perlin_0",
+			"from_port": 0,
+			"to": "Warp",
+			"to_port": 1
+		},
+		{
+			"from": "uniform_0",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 1
+		},
+		{
+			"from": "blend_2",
+			"from_port": 0,
+			"to": "colorize_4",
+			"to_port": 0
+		},
+		{
+			"from": "voronoi_0",
+			"from_port": 1,
+			"to": "colorize_5",
+			"to_port": 0
+		},
+		{
+			"from": "blend_0",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_2",
+			"from_port": 0,
+			"to": "colorize_7",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_7",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 2
+		},
+		{
+			"from": "Bricks",
+			"from_port": 0,
+			"to": "Warp",
+			"to_port": 0
+		},
+		{
+			"from": "Bricks",
+			"from_port": 1,
+			"to": "blend_1",
+			"to_port": 1
+		},
+		{
+			"from": "colorize_1",
+			"from_port": 0,
+			"to": "blend_0",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_4",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 5
+		},
+		{
+			"from": "uniform_0",
+			"from_port": 0,
+			"to": "combine_0",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_7",
+			"from_port": 0,
+			"to": "combine_0",
+			"to_port": 1
+		},
+		{
+			"from": "normal_map_0",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 4
+		},
+		{
+			"from": "colorize_6",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 6
+		},
+		{
+			"from": "blend_2",
+			"from_port": 0,
+			"to": "normal_map_0",
+			"to_port": 0
+		}
+	],
+	"label": "Graph",
+	"name": "446",
+	"node_position": {
+		"x": 0,
+		"y": 0
+	},
+	"nodes": [
+		{
+			"name": "voronoi_0",
+			"node_position": {
+				"x": -288,
+				"y": -107
+			},
+			"parameters": {
+				"intensity": 1,
+				"randomness": 1,
+				"scale_x": 8,
+				"scale_y": 8
+			},
+			"type": "voronoi"
+		},
+		{
+			"name": "colorize_5",
+			"node_position": {
+				"x": -104,
+				"y": -87
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0.027273,
+							"r": 0
+						},
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0.1,
+							"r": 1
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "colorize_0",
+			"node_position": {
+				"x": 560.943665,
+				"y": 50
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0,
+							"r": 0
+						},
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 1,
+							"r": 1
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "perlin_0",
+			"node_position": {
+				"x": 13,
+				"y": 218
+			},
+			"parameters": {
+				"iterations": 4,
+				"persistence": 0.75,
+				"scale_x": 4,
+				"scale_y": 4
+			},
+			"type": "perlin"
+		},
+		{
+			"name": "colorize_1",
+			"node_position": {
+				"x": 393.943665,
+				"y": -124
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0.557292,
+							"g": 0.557292,
+							"pos": 0,
+							"r": 0.557292
+						},
+						{
+							"a": 1,
+							"b": 0.180664,
+							"g": 0.22934,
+							"pos": 0.145455,
+							"r": 0.234375
+						},
+						{
+							"a": 1,
+							"b": 0.585504,
+							"g": 0.672174,
+							"pos": 0.345455,
+							"r": 0.739583
+						},
+						{
+							"a": 1,
+							"b": 0.144423,
+							"g": 0.184147,
+							"pos": 0.545455,
+							"r": 0.229167
+						},
+						{
+							"a": 1,
+							"b": 0.447537,
+							"g": 0.553291,
+							"pos": 0.745455,
+							"r": 0.588542
+						},
+						{
+							"a": 1,
+							"b": 0.199002,
+							"g": 0.342478,
+							"pos": 1,
+							"r": 0.682292
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "blend_1",
+			"node_position": {
+				"x": 286,
+				"y": 252
+			},
+			"parameters": {
+				"amount": 0.5,
+				"blend_type": 6
+			},
+			"type": "blend"
+		},
+		{
+			"name": "Perlin",
+			"node_position": {
+				"x": 74,
+				"y": -255
+			},
+			"parameters": {
+				"iterations": 8,
+				"persistence": 0.8,
+				"scale_x": 4,
+				"scale_y": 4
+			},
+			"type": "perlin"
+		},
+		{
+			"name": "colorize_2",
+			"node_position": {
+				"x": 535.943665,
+				"y": 163
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0,
+							"r": 0
+						},
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0.045455,
+							"r": 1
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "colorize_6",
+			"node_position": {
+				"x": 732,
+				"y": 195
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0,
+							"r": 1
+						},
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 1,
+							"r": 0
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "blend_0",
+			"node_position": {
+				"x": 763.943726,
+				"y": 13
+			},
+			"parameters": {
+				"amount": 1,
+				"blend_type": 0
+			},
+			"type": "blend"
+		},
+		{
+			"name": "uniform_0",
+			"node_position": {
+				"x": 931,
+				"y": 95
+			},
+			"parameters": {
+				"color": {
+					"a": 1,
+					"b": 0,
+					"g": 0,
+					"r": 0,
+					"type": "Color"
+				}
+			},
+			"type": "uniform"
+		},
+		{
+			"name": "Material",
+			"node_position": {
+				"x": 1161,
+				"y": 114
+			},
+			"parameters": {
+				"albedo_color": {
+					"a": 1,
+					"b": 1,
+					"g": 1,
+					"r": 1,
+					"type": "Color"
+				},
+				"ao_light_affect": 1,
+				"depth_scale": 0.2,
+				"emission_energy": 1,
+				"metallic": 1,
+				"normal_scale": 1,
+				"resolution": 1,
+				"roughness": 1,
+				"size": 11
+			},
+			"type": "material"
+		},
+		{
+			"name": "combine_0",
+			"node_position": {
+				"x": 1119.687012,
+				"y": -22.258774
+			},
+			"parameters": {
+				"color": {
+					"a": 1,
+					"b": 1,
+					"g": 1,
+					"r": 1,
+					"type": "Color"
+				},
+				"name": 0
+			},
+			"type": "combine"
+		},
+		{
+			"name": "colorize_7",
+			"node_position": {
+				"x": 915.356934,
+				"y": 149
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0,
+							"r": 1
+						},
+						{
+							"a": 1,
+							"b": 0.479167,
+							"g": 0.479167,
+							"pos": 0.136364,
+							"r": 0.479167
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "colorize_4",
+			"node_position": {
+				"x": 787,
+				"y": 296
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0.15625,
+							"g": 0.15625,
+							"pos": 0,
+							"r": 0.15625
+						},
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0.454545,
+							"r": 1
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "normal_map_0",
+			"node_position": {
+				"x": 926.587036,
+				"y": 211.716217
+			},
+			"parameters": {
+				"amount": 0.5,
+				"param0": 11,
+				"param1": 11,
+				"param2": 1,
+				"size": 4
+			},
+			"type": "normal_map"
+		},
+		{
+			"name": "Warp",
+			"node_position": {
+				"x": 298,
+				"y": 88.75
+			},
+			"parameters": {
+				"amount": 0.05,
+				"eps": 0.05,
+				"epsilon": 0
+			},
+			"type": "warp"
+		},
+		{
+			"name": "blend_2",
+			"node_position": {
+				"x": 537,
+				"y": 264
+			},
+			"parameters": {
+				"amount": 0.5,
+				"blend_type": 0
+			},
+			"type": "blend"
+		},
+		{
+			"name": "Bricks",
+			"node_position": {
+				"x": -56,
+				"y": -6
+			},
+			"parameters": {
+				"bevel": 0.15,
+				"columns": 3,
+				"mortar": 0.05,
+				"pattern": 0,
+				"repeat": 1,
+				"row_offset": 0.5,
+				"rows": 6
+			},
+			"type": "bricks"
+		}
+	],
+	"parameters": {
+
+	},
+	"type": "graph"
+}

--- a/addons/material_maker/examples/tiles.ptex
+++ b/addons/material_maker/examples/tiles.ptex
@@ -1,1 +1,357 @@
-{"connections":[{"from":"shape","from_port":0,"to":"blend","to_port":0},{"from":"pattern","from_port":0,"to":"blend","to_port":1},{"from":"blend","from_port":0,"to":"transform","to_port":0},{"from":"transform_2","from_port":0,"to":"blend_2","to_port":1},{"from":"transform","from_port":0,"to":"blend_2","to_port":0},{"from":"bricks","from_port":1,"to":"transform_2_2","to_port":0},{"from":"transform_2_2","from_port":0,"to":"blend_3","to_port":0},{"from":"bricks","from_port":1,"to":"blend_3","to_port":1},{"from":"transform_2","from_port":0,"to":"blend_4","to_port":0},{"from":"transform","from_port":0,"to":"blend_4","to_port":1},{"from":"transform","from_port":0,"to":"transform_2","to_port":0},{"from":"blend_4","from_port":0,"to":"colorize","to_port":0},{"from":"colorize","from_port":0,"to":"blend_3","to_port":2},{"from":"blend_2","from_port":0,"to":"normal_map","to_port":0},{"from":"normal_map","from_port":0,"to":"Material","to_port":4},{"from":"blend_3","from_port":0,"to":"colorize_2","to_port":0},{"from":"colorize_2","from_port":0,"to":"Material","to_port":0}],"label":"Graph","name":"39","node_position":{"x":0,"y":0},"nodes":[{"name":"Material","node_position":{"x":510,"y":-55},"parameters":{"albedo_color":{"a":1,"b":1,"g":1,"r":1,"type":"Color"},"ao_light_affect":1,"depth_scale":1,"emission_energy":0.45,"metallic":1,"normal_scale":2.15,"roughness":1,"size":11},"type":"material"},{"name":"shape","node_position":{"x":-624.5,"y":-157.5},"parameters":{"edge":0.0625,"radius":1,"shape":0,"sides":6},"type":"shape"},{"name":"transform","node_position":{"x":-445.5,"y":-87.5},"parameters":{"repeat":true,"rotate":0,"scale_x":0.125,"scale_y":0.125,"translate_x":0,"translate_y":0},"type":"transform"},{"name":"pattern","node_position":{"x":-726.5,"y":-55.5},"parameters":{"mix":0,"x_scale":2,"x_wave":4,"y_scale":1,"y_wave":3},"type":"pattern"},{"name":"blend","node_position":{"x":-444.240479,"y":-198.5},"parameters":{"amount":1,"blend_type":2},"type":"blend"},{"name":"transform_2","node_position":{"x":-222.240479,"y":-85.5},"parameters":{"repeat":true,"rotate":0,"scale_x":1,"scale_y":1,"translate_x":0.06,"translate_y":0.06},"type":"transform"},{"name":"blend_2","node_position":{"x":-167.240479,"y":-198.5},"parameters":{"amount":1,"blend_type":9},"type":"blend"},{"name":"bricks","node_position":{"x":-506.407684,"y":150.5},"parameters":{"bevel":0,"columns":8,"mortar":0.1,"pattern":0,"repeat":1,"row_offset":0,"rows":8},"type":"bricks"},{"name":"blend_3","node_position":{"x":2.592316,"y":168.5},"parameters":{"amount":1,"blend_type":0},"type":"blend"},{"name":"transform_2_2","node_position":{"x":-262.407715,"y":140},"parameters":{"repeat":true,"rotate":0,"scale_x":1,"scale_y":1,"translate_x":0.56,"translate_y":0.56},"type":"transform"},{"name":"blend_4","node_position":{"x":5.592316,"y":65.5},"parameters":{"amount":1,"blend_type":11},"type":"blend"},{"name":"colorize","node_position":{"x":-14.407684,"y":262.5},"parameters":{"gradient":{"points":[{"a":1,"b":0,"g":0,"pos":0,"r":0},{"a":1,"b":1,"g":1,"pos":0.072727,"r":1}],"type":"Gradient"}},"type":"colorize"},{"name":"normal_map","node_position":{"x":83.448486,"y":-87.5},"parameters":{"amount":0.5,"param0":11,"param1":0.69,"size":4},"type":"normal_map"},{"name":"colorize_2","node_position":{"x":217.448486,"y":41.5},"parameters":{"gradient":{"points":[{"a":1,"b":0,"g":0.375,"pos":0,"r":1},{"a":1,"b":0,"g":0.300293,"pos":1,"r":0.640625}],"type":"Gradient"}},"type":"colorize"}],"parameters":{},"type":"graph"}
+{
+	"connections": [
+		{
+			"from": "shape",
+			"from_port": 0,
+			"to": "blend",
+			"to_port": 0
+		},
+		{
+			"from": "pattern",
+			"from_port": 0,
+			"to": "blend",
+			"to_port": 1
+		},
+		{
+			"from": "blend",
+			"from_port": 0,
+			"to": "transform",
+			"to_port": 0
+		},
+		{
+			"from": "transform_2",
+			"from_port": 0,
+			"to": "blend_2",
+			"to_port": 1
+		},
+		{
+			"from": "transform",
+			"from_port": 0,
+			"to": "blend_2",
+			"to_port": 0
+		},
+		{
+			"from": "bricks",
+			"from_port": 1,
+			"to": "transform_2_2",
+			"to_port": 0
+		},
+		{
+			"from": "transform_2_2",
+			"from_port": 0,
+			"to": "blend_3",
+			"to_port": 0
+		},
+		{
+			"from": "bricks",
+			"from_port": 1,
+			"to": "blend_3",
+			"to_port": 1
+		},
+		{
+			"from": "transform_2",
+			"from_port": 0,
+			"to": "blend_4",
+			"to_port": 0
+		},
+		{
+			"from": "transform",
+			"from_port": 0,
+			"to": "blend_4",
+			"to_port": 1
+		},
+		{
+			"from": "transform",
+			"from_port": 0,
+			"to": "transform_2",
+			"to_port": 0
+		},
+		{
+			"from": "blend_4",
+			"from_port": 0,
+			"to": "colorize",
+			"to_port": 0
+		},
+		{
+			"from": "colorize",
+			"from_port": 0,
+			"to": "blend_3",
+			"to_port": 2
+		},
+		{
+			"from": "blend_2",
+			"from_port": 0,
+			"to": "normal_map",
+			"to_port": 0
+		},
+		{
+			"from": "normal_map",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 4
+		},
+		{
+			"from": "blend_3",
+			"from_port": 0,
+			"to": "colorize_2",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_2",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 0
+		}
+	],
+	"label": "Graph",
+	"name": "39",
+	"node_position": {
+		"x": 0,
+		"y": 0
+	},
+	"nodes": [
+		{
+			"name": "Material",
+			"node_position": {
+				"x": 510,
+				"y": -55
+			},
+			"parameters": {
+				"albedo_color": {
+					"a": 1,
+					"b": 1,
+					"g": 1,
+					"r": 1,
+					"type": "Color"
+				},
+				"ao_light_affect": 1,
+				"depth_scale": 1,
+				"emission_energy": 0.45,
+				"metallic": 1,
+				"normal_scale": 2.15,
+				"roughness": 1,
+				"size": 11
+			},
+			"type": "material"
+		},
+		{
+			"name": "shape",
+			"node_position": {
+				"x": -624.5,
+				"y": -157.5
+			},
+			"parameters": {
+				"edge": 0.0625,
+				"radius": 1,
+				"shape": 0,
+				"sides": 6
+			},
+			"type": "shape"
+		},
+		{
+			"name": "transform",
+			"node_position": {
+				"x": -445.5,
+				"y": -87.5
+			},
+			"parameters": {
+				"repeat": true,
+				"rotate": 0,
+				"scale_x": 0.125,
+				"scale_y": 0.125,
+				"translate_x": 0,
+				"translate_y": 0
+			},
+			"type": "transform"
+		},
+		{
+			"name": "pattern",
+			"node_position": {
+				"x": -726.5,
+				"y": -55.5
+			},
+			"parameters": {
+				"mix": 0,
+				"x_scale": 2,
+				"x_wave": 4,
+				"y_scale": 1,
+				"y_wave": 3
+			},
+			"type": "pattern"
+		},
+		{
+			"name": "blend",
+			"node_position": {
+				"x": -444.240479,
+				"y": -198.5
+			},
+			"parameters": {
+				"amount": 1,
+				"blend_type": 2
+			},
+			"type": "blend"
+		},
+		{
+			"name": "transform_2",
+			"node_position": {
+				"x": -222.240479,
+				"y": -85.5
+			},
+			"parameters": {
+				"repeat": true,
+				"rotate": 0,
+				"scale_x": 1,
+				"scale_y": 1,
+				"translate_x": 0.06,
+				"translate_y": 0.06
+			},
+			"type": "transform"
+		},
+		{
+			"name": "blend_2",
+			"node_position": {
+				"x": -167.240479,
+				"y": -198.5
+			},
+			"parameters": {
+				"amount": 1,
+				"blend_type": 9
+			},
+			"type": "blend"
+		},
+		{
+			"name": "bricks",
+			"node_position": {
+				"x": -506.407684,
+				"y": 150.5
+			},
+			"parameters": {
+				"bevel": 0,
+				"columns": 8,
+				"mortar": 0.1,
+				"pattern": 0,
+				"repeat": 1,
+				"row_offset": 0,
+				"rows": 8
+			},
+			"type": "bricks"
+		},
+		{
+			"name": "blend_3",
+			"node_position": {
+				"x": 2.592316,
+				"y": 168.5
+			},
+			"parameters": {
+				"amount": 1,
+				"blend_type": 0
+			},
+			"type": "blend"
+		},
+		{
+			"name": "transform_2_2",
+			"node_position": {
+				"x": -262.407715,
+				"y": 140
+			},
+			"parameters": {
+				"repeat": true,
+				"rotate": 0,
+				"scale_x": 1,
+				"scale_y": 1,
+				"translate_x": 0.56,
+				"translate_y": 0.56
+			},
+			"type": "transform"
+		},
+		{
+			"name": "blend_4",
+			"node_position": {
+				"x": 5.592316,
+				"y": 65.5
+			},
+			"parameters": {
+				"amount": 1,
+				"blend_type": 11
+			},
+			"type": "blend"
+		},
+		{
+			"name": "colorize",
+			"node_position": {
+				"x": -14.407684,
+				"y": 262.5
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0,
+							"r": 0
+						},
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0.072727,
+							"r": 1
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "normal_map",
+			"node_position": {
+				"x": 83.448486,
+				"y": -87.5
+			},
+			"parameters": {
+				"amount": 0.5,
+				"param0": 11,
+				"param1": 11,
+				"param2": 1,
+				"size": 4
+			},
+			"type": "normal_map"
+		},
+		{
+			"name": "colorize_2",
+			"node_position": {
+				"x": 217.448486,
+				"y": 41.5
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0.375,
+							"pos": 0,
+							"r": 1
+						},
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0.300293,
+							"pos": 1,
+							"r": 0.640625
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		}
+	],
+	"parameters": {
+
+	},
+	"type": "graph"
+}

--- a/addons/material_maker/examples/wood.ptex
+++ b/addons/material_maker/examples/wood.ptex
@@ -1,1 +1,351 @@
-{"connections":[{"from":"perlin_0","from_port":0,"to":"warp_0","to_port":0},{"from":"perlin_1","from_port":0,"to":"warp_0","to_port":1},{"from":"perlin_2","from_port":0,"to":"blend_0","to_port":0},{"from":"blend_0","from_port":0,"to":"normal_map_0","to_port":0},{"from":"normal_map_0","from_port":0,"to":"Material","to_port":4},{"from":"blend_0","from_port":0,"to":"colorize_0","to_port":0},{"from":"colorize_0","from_port":0,"to":"Material","to_port":2},{"from":"blend_0","from_port":0,"to":"Material","to_port":1},{"from":"voronoi_0","from_port":0,"to":"colorize_1","to_port":0},{"from":"warp_0","from_port":0,"to":"warp_1","to_port":0},{"from":"colorize_1","from_port":0,"to":"warp_1","to_port":1},{"from":"warp_1","from_port":0,"to":"blend_0","to_port":1},{"from":"colorize_0","from_port":0,"to":"combine_0","to_port":1},{"from":"blend_0","from_port":0,"to":"colorize_2","to_port":0},{"from":"blend_0","from_port":0,"to":"combine_0","to_port":0},{"from":"colorize_2","from_port":0,"to":"Material","to_port":0}],"label":"Graph","name":"475","node_position":{"x":0,"y":0},"nodes":[{"name":"perlin_2","node_position":{"x":-312,"y":2.5},"parameters":{"iterations":6,"persistence":1,"scale_x":32,"scale_y":4},"type":"perlin"},{"name":"perlin_1","node_position":{"x":-424,"y":343.5},"parameters":{"iterations":3,"persistence":0.5,"scale_x":4,"scale_y":4},"type":"perlin"},{"name":"perlin_0","node_position":{"x":-424,"y":212.5},"parameters":{"iterations":3,"persistence":0.5,"scale_x":32,"scale_y":4},"type":"perlin"},{"name":"warp_0","node_position":{"x":-180,"y":317.5},"parameters":{"amount":0.1,"eps":0.05,"epsilon":0},"type":"warp"},{"name":"colorize_1","node_position":{"x":-194,"y":466.5},"parameters":{"gradient":{"points":[{"a":1,"b":0.432292,"g":0.432292,"pos":0,"r":0.432292},{"a":1,"b":0,"g":0,"pos":0.345455,"r":0}],"type":"Gradient"}},"type":"colorize"},{"name":"warp_1","node_position":{"x":-31,"y":349.5},"parameters":{"amount":0.1,"eps":0.045,"epsilon":0},"type":"warp"},{"name":"voronoi_0","node_position":{"x":-437,"y":484.5},"parameters":{"intensity":1,"randomness":1,"scale_x":5,"scale_y":4},"type":"voronoi"},{"name":"blend_0","node_position":{"x":83,"y":245.5},"parameters":{"amount":1,"blend_type":2},"type":"blend"},{"name":"combine_0","node_position":{"x":515.35144,"y":-15.818176},"parameters":{"color":{"a":1,"b":1,"g":1,"r":1,"type":"Color"},"name":0},"type":"combine"},{"name":"Material","node_position":{"x":544,"y":79},"parameters":{"albedo_color":{"a":1,"b":1,"g":1,"r":1,"type":"Color"},"ao_light_affect":1,"depth_scale":1,"emission_energy":1,"metallic":1,"normal_scale":1,"resolution":1,"roughness":1,"size":11},"type":"material"},{"name":"colorize_2","node_position":{"x":305.35144,"y":76.181824},"parameters":{"gradient":{"points":[{"a":1,"b":0.071126,"g":0.34877,"pos":0,"r":0.59375},{"a":1,"b":0.013021,"g":0.144043,"pos":1,"r":0.3125}],"type":"Gradient"}},"type":"colorize"},{"name":"normal_map_0","node_position":{"x":319,"y":265.5},"parameters":{"amount":0.1,"param0":11,"param1":0.99,"size":5},"type":"normal_map"},{"name":"colorize_0","node_position":{"x":313,"y":176.5},"parameters":{"gradient":{"points":[{"a":1,"b":0.53125,"g":0.53125,"pos":0,"r":0.53125},{"a":1,"b":0.708333,"g":0.708333,"pos":1,"r":0.708333}],"type":"Gradient"}},"type":"colorize"}],"parameters":{},"type":"graph"}
+{
+	"connections": [
+		{
+			"from": "perlin_0",
+			"from_port": 0,
+			"to": "warp_0",
+			"to_port": 0
+		},
+		{
+			"from": "perlin_1",
+			"from_port": 0,
+			"to": "warp_0",
+			"to_port": 1
+		},
+		{
+			"from": "perlin_2",
+			"from_port": 0,
+			"to": "blend_0",
+			"to_port": 0
+		},
+		{
+			"from": "blend_0",
+			"from_port": 0,
+			"to": "normal_map_0",
+			"to_port": 0
+		},
+		{
+			"from": "normal_map_0",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 4
+		},
+		{
+			"from": "blend_0",
+			"from_port": 0,
+			"to": "colorize_0",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_0",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 2
+		},
+		{
+			"from": "blend_0",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 1
+		},
+		{
+			"from": "voronoi_0",
+			"from_port": 0,
+			"to": "colorize_1",
+			"to_port": 0
+		},
+		{
+			"from": "warp_0",
+			"from_port": 0,
+			"to": "warp_1",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_1",
+			"from_port": 0,
+			"to": "warp_1",
+			"to_port": 1
+		},
+		{
+			"from": "warp_1",
+			"from_port": 0,
+			"to": "blend_0",
+			"to_port": 1
+		},
+		{
+			"from": "colorize_0",
+			"from_port": 0,
+			"to": "combine_0",
+			"to_port": 1
+		},
+		{
+			"from": "blend_0",
+			"from_port": 0,
+			"to": "colorize_2",
+			"to_port": 0
+		},
+		{
+			"from": "blend_0",
+			"from_port": 0,
+			"to": "combine_0",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_2",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 0
+		}
+	],
+	"label": "Graph",
+	"name": "475",
+	"node_position": {
+		"x": 0,
+		"y": 0
+	},
+	"nodes": [
+		{
+			"name": "perlin_2",
+			"node_position": {
+				"x": -312,
+				"y": 2.5
+			},
+			"parameters": {
+				"iterations": 6,
+				"persistence": 1,
+				"scale_x": 32,
+				"scale_y": 4
+			},
+			"type": "perlin"
+		},
+		{
+			"name": "perlin_1",
+			"node_position": {
+				"x": -424,
+				"y": 343.5
+			},
+			"parameters": {
+				"iterations": 3,
+				"persistence": 0.5,
+				"scale_x": 4,
+				"scale_y": 4
+			},
+			"type": "perlin"
+		},
+		{
+			"name": "perlin_0",
+			"node_position": {
+				"x": -424,
+				"y": 212.5
+			},
+			"parameters": {
+				"iterations": 3,
+				"persistence": 0.5,
+				"scale_x": 32,
+				"scale_y": 4
+			},
+			"type": "perlin"
+		},
+		{
+			"name": "warp_0",
+			"node_position": {
+				"x": -180,
+				"y": 317.5
+			},
+			"parameters": {
+				"amount": 0.1,
+				"eps": 0.05,
+				"epsilon": 0
+			},
+			"type": "warp"
+		},
+		{
+			"name": "colorize_1",
+			"node_position": {
+				"x": -194,
+				"y": 466.5
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0.432292,
+							"g": 0.432292,
+							"pos": 0,
+							"r": 0.432292
+						},
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0.345455,
+							"r": 0
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "warp_1",
+			"node_position": {
+				"x": -31,
+				"y": 349.5
+			},
+			"parameters": {
+				"amount": 0.1,
+				"eps": 0.045,
+				"epsilon": 0
+			},
+			"type": "warp"
+		},
+		{
+			"name": "voronoi_0",
+			"node_position": {
+				"x": -437,
+				"y": 484.5
+			},
+			"parameters": {
+				"intensity": 1,
+				"randomness": 1,
+				"scale_x": 5,
+				"scale_y": 4
+			},
+			"type": "voronoi"
+		},
+		{
+			"name": "blend_0",
+			"node_position": {
+				"x": 83,
+				"y": 245.5
+			},
+			"parameters": {
+				"amount": 1,
+				"blend_type": 2
+			},
+			"type": "blend"
+		},
+		{
+			"name": "combine_0",
+			"node_position": {
+				"x": 515.35144,
+				"y": -15.818176
+			},
+			"parameters": {
+				"color": {
+					"a": 1,
+					"b": 1,
+					"g": 1,
+					"r": 1,
+					"type": "Color"
+				},
+				"name": 0
+			},
+			"type": "combine"
+		},
+		{
+			"name": "Material",
+			"node_position": {
+				"x": 544,
+				"y": 79
+			},
+			"parameters": {
+				"albedo_color": {
+					"a": 1,
+					"b": 1,
+					"g": 1,
+					"r": 1,
+					"type": "Color"
+				},
+				"ao_light_affect": 1,
+				"depth_scale": 1,
+				"emission_energy": 1,
+				"metallic": 1,
+				"normal_scale": 1,
+				"resolution": 1,
+				"roughness": 1,
+				"size": 11
+			},
+			"type": "material"
+		},
+		{
+			"name": "colorize_2",
+			"node_position": {
+				"x": 305.35144,
+				"y": 76.181824
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0.071126,
+							"g": 0.34877,
+							"pos": 0,
+							"r": 0.59375
+						},
+						{
+							"a": 1,
+							"b": 0.013021,
+							"g": 0.144043,
+							"pos": 1,
+							"r": 0.3125
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "normal_map_0",
+			"node_position": {
+				"x": 319,
+				"y": 265.5
+			},
+			"parameters": {
+				"amount": 0.1,
+				"param0": 11,
+				"param1": 11,
+				"param2": 1,
+				"size": 5
+			},
+			"type": "normal_map"
+		},
+		{
+			"name": "colorize_0",
+			"node_position": {
+				"x": 313,
+				"y": 176.5
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0.53125,
+							"g": 0.53125,
+							"pos": 0,
+							"r": 0.53125
+						},
+						{
+							"a": 1,
+							"b": 0.708333,
+							"g": 0.708333,
+							"pos": 1,
+							"r": 0.708333
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		}
+	],
+	"parameters": {
+
+	},
+	"type": "graph"
+}

--- a/addons/material_maker/examples/wood_with_blood.ptex
+++ b/addons/material_maker/examples/wood_with_blood.ptex
@@ -1,1 +1,490 @@
-{"connections":[{"from":"bricks_0","from_port":0,"to":"blend_0","to_port":0},{"from":"perlin_0","from_port":0,"to":"blend_0","to_port":1},{"from":"normal_map_0","from_port":0,"to":"Material","to_port":4},{"from":"perlin_1","from_port":0,"to":"colorize_2","to_port":0},{"from":"colorize_0","from_port":0,"to":"blend_1","to_port":1},{"from":"perlin_2","from_port":0,"to":"colorize_3","to_port":0},{"from":"colorize_3","from_port":0,"to":"blend_1","to_port":2},{"from":"blend_1","from_port":0,"to":"Material","to_port":0},{"from":"colorize_3","from_port":0,"to":"blend_2","to_port":0},{"from":"blend_2","from_port":0,"to":"Material","to_port":2},{"from":"blend_0","from_port":0,"to":"colorize_0","to_port":0},{"from":"uniform_1","from_port":0,"to":"Material","to_port":1},{"from":"uniform_0","from_port":0,"to":"blend_2","to_port":1},{"from":"perlin_1","from_port":0,"to":"colorize_1","to_port":0},{"from":"uniform_1","from_port":0,"to":"combine_0","to_port":0},{"from":"blend_2","from_port":0,"to":"combine_0","to_port":1},{"from":"colorize_2","from_port":0,"to":"blend_1","to_port":0},{"from":"blend_0","from_port":0,"to":"normal_map_0","to_port":0}],"label":"Graph","name":"505","node_position":{"x":0,"y":0},"nodes":[{"name":"Material","node_position":{"x":938,"y":96},"parameters":{"albedo_color":{"a":1,"b":1,"g":1,"r":1,"type":"Color"},"ao_light_affect":1,"depth_scale":1,"emission_energy":1,"metallic":1,"normal_scale":1,"resolution":1,"roughness":1,"size":11},"type":"material"},{"name":"colorize_3","node_position":{"x":487.633789,"y":65},"parameters":{"gradient":{"points":[{"a":1,"b":0,"g":0,"pos":0.5,"r":0},{"a":1,"b":1,"g":1,"pos":0.672727,"r":1}],"type":"Gradient"}},"type":"colorize"},{"name":"bricks_0","node_position":{"x":-21,"y":70.5},"parameters":{"bevel":0.007813,"columns":5,"mortar":0.025469,"pattern":0,"repeat":1,"row_offset":0.5,"rows":1},"type":"bricks"},{"name":"colorize_0","node_position":{"x":472,"y":-41.5},"parameters":{"gradient":{"points":[{"a":1,"b":0,"g":0.336914,"pos":0,"r":0.598958},{"a":1,"b":0,"g":0.454102,"pos":0.118182,"r":0.807292},{"a":1,"b":0,"g":0.37793,"pos":0.245455,"r":0.671875},{"a":1,"b":0,"g":0.427734,"pos":0.345455,"r":0.760417},{"a":1,"b":0.017795,"g":0.488254,"pos":0.527273,"r":0.854167},{"a":1,"b":0,"g":0.37793,"pos":0.645455,"r":0.671875},{"a":1,"b":0,"g":0.439453,"pos":0.845455,"r":0.78125},{"a":1,"b":0,"g":0.357422,"pos":1,"r":0.635417}],"type":"Gradient"}},"type":"colorize"},{"name":"perlin_1","node_position":{"x":110.633789,"y":-143.5},"parameters":{"iterations":7,"persistence":0.55,"scale_x":4,"scale_y":4},"type":"perlin"},{"name":"blend_2","node_position":{"x":690.633789,"y":201.5},"parameters":{"amount":0.4,"blend_type":0},"type":"blend"},{"name":"perlin_2","node_position":{"x":232.633789,"y":40},"parameters":{"iterations":6,"persistence":0.65,"scale_x":4,"scale_y":4},"type":"perlin"},{"name":"normal_map_0","node_position":{"x":724.633789,"y":345.5},"parameters":{"amount":0.15,"param0":11,"param1":0.99,"size":4},"type":"normal_map"},{"name":"blend_1","node_position":{"x":707.633789,"y":-68},"parameters":{"amount":1,"blend_type":0},"type":"blend"},{"name":"blend_0","node_position":{"x":222,"y":265.5},"parameters":{"amount":1,"blend_type":2},"type":"blend"},{"name":"uniform_1","node_position":{"x":753,"y":116},"parameters":{"color":{"a":1,"b":0,"g":0,"r":0,"type":"Color"}},"type":"uniform"},{"name":"uniform_0","node_position":{"x":540,"y":234},"parameters":{"color":{"a":1,"b":1,"g":1,"r":1,"type":"Color"}},"type":"uniform"},{"name":"colorize_2","node_position":{"x":454.633789,"y":-189.5},"parameters":{"gradient":{"points":[{"a":1,"b":0,"g":0,"pos":0,"r":0.515625},{"a":1,"b":0,"g":0,"pos":0.145455,"r":0.25},{"a":1,"b":0,"g":0,"pos":0.445455,"r":0.515625},{"a":1,"b":0.013184,"g":0.013184,"pos":0.745455,"r":0.28125},{"a":1,"b":0,"g":0,"pos":1,"r":0.322917}],"type":"Gradient"}},"type":"colorize"},{"name":"colorize_1","node_position":{"x":461.329102,"y":-116.699997},"parameters":{"gradient":{"points":[{"a":1,"b":0.034912,"g":0.129532,"pos":0,"r":0.203125},{"a":1,"b":0.038791,"g":0.074319,"pos":1,"r":0.114583}],"type":"Gradient"}},"type":"colorize"},{"name":"combine_0","node_position":{"x":942.329102,"y":-55.5},"parameters":{"color":{"a":1,"b":1,"g":1,"r":1,"type":"Color"},"name":0},"type":"combine"},{"name":"perlin_0","node_position":{"x":-20,"y":279.5},"parameters":{"iterations":6,"persistence":0.7,"scale_x":20,"scale_y":3},"type":"perlin"}],"parameters":{},"type":"graph"}
+{
+	"connections": [
+		{
+			"from": "bricks_0",
+			"from_port": 0,
+			"to": "blend_0",
+			"to_port": 0
+		},
+		{
+			"from": "perlin_0",
+			"from_port": 0,
+			"to": "blend_0",
+			"to_port": 1
+		},
+		{
+			"from": "normal_map_0",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 4
+		},
+		{
+			"from": "perlin_1",
+			"from_port": 0,
+			"to": "colorize_2",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_0",
+			"from_port": 0,
+			"to": "blend_1",
+			"to_port": 1
+		},
+		{
+			"from": "perlin_2",
+			"from_port": 0,
+			"to": "colorize_3",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_3",
+			"from_port": 0,
+			"to": "blend_1",
+			"to_port": 2
+		},
+		{
+			"from": "blend_1",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_3",
+			"from_port": 0,
+			"to": "blend_2",
+			"to_port": 0
+		},
+		{
+			"from": "blend_2",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 2
+		},
+		{
+			"from": "blend_0",
+			"from_port": 0,
+			"to": "colorize_0",
+			"to_port": 0
+		},
+		{
+			"from": "uniform_1",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 1
+		},
+		{
+			"from": "uniform_0",
+			"from_port": 0,
+			"to": "blend_2",
+			"to_port": 1
+		},
+		{
+			"from": "perlin_1",
+			"from_port": 0,
+			"to": "colorize_1",
+			"to_port": 0
+		},
+		{
+			"from": "uniform_1",
+			"from_port": 0,
+			"to": "combine_0",
+			"to_port": 0
+		},
+		{
+			"from": "blend_2",
+			"from_port": 0,
+			"to": "combine_0",
+			"to_port": 1
+		},
+		{
+			"from": "colorize_2",
+			"from_port": 0,
+			"to": "blend_1",
+			"to_port": 0
+		},
+		{
+			"from": "blend_0",
+			"from_port": 0,
+			"to": "normal_map_0",
+			"to_port": 0
+		}
+	],
+	"label": "Graph",
+	"name": "505",
+	"node_position": {
+		"x": 0,
+		"y": 0
+	},
+	"nodes": [
+		{
+			"name": "Material",
+			"node_position": {
+				"x": 938,
+				"y": 96
+			},
+			"parameters": {
+				"albedo_color": {
+					"a": 1,
+					"b": 1,
+					"g": 1,
+					"r": 1,
+					"type": "Color"
+				},
+				"ao_light_affect": 1,
+				"depth_scale": 1,
+				"emission_energy": 1,
+				"metallic": 1,
+				"normal_scale": 1,
+				"resolution": 1,
+				"roughness": 1,
+				"size": 11
+			},
+			"type": "material"
+		},
+		{
+			"name": "colorize_3",
+			"node_position": {
+				"x": 487.633789,
+				"y": 65
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0.5,
+							"r": 0
+						},
+						{
+							"a": 1,
+							"b": 1,
+							"g": 1,
+							"pos": 0.672727,
+							"r": 1
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "bricks_0",
+			"node_position": {
+				"x": -21,
+				"y": 70.5
+			},
+			"parameters": {
+				"bevel": 0.007813,
+				"columns": 5,
+				"mortar": 0.025469,
+				"pattern": 0,
+				"repeat": 1,
+				"row_offset": 0.5,
+				"rows": 1
+			},
+			"type": "bricks"
+		},
+		{
+			"name": "colorize_0",
+			"node_position": {
+				"x": 472,
+				"y": -41.5
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0.336914,
+							"pos": 0,
+							"r": 0.598958
+						},
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0.454102,
+							"pos": 0.118182,
+							"r": 0.807292
+						},
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0.37793,
+							"pos": 0.245455,
+							"r": 0.671875
+						},
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0.427734,
+							"pos": 0.345455,
+							"r": 0.760417
+						},
+						{
+							"a": 1,
+							"b": 0.017795,
+							"g": 0.488254,
+							"pos": 0.527273,
+							"r": 0.854167
+						},
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0.37793,
+							"pos": 0.645455,
+							"r": 0.671875
+						},
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0.439453,
+							"pos": 0.845455,
+							"r": 0.78125
+						},
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0.357422,
+							"pos": 1,
+							"r": 0.635417
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "perlin_1",
+			"node_position": {
+				"x": 110.633789,
+				"y": -143.5
+			},
+			"parameters": {
+				"iterations": 7,
+				"persistence": 0.55,
+				"scale_x": 4,
+				"scale_y": 4
+			},
+			"type": "perlin"
+		},
+		{
+			"name": "blend_2",
+			"node_position": {
+				"x": 690.633789,
+				"y": 201.5
+			},
+			"parameters": {
+				"amount": 0.4,
+				"blend_type": 0
+			},
+			"type": "blend"
+		},
+		{
+			"name": "perlin_2",
+			"node_position": {
+				"x": 232.633789,
+				"y": 40
+			},
+			"parameters": {
+				"iterations": 6,
+				"persistence": 0.65,
+				"scale_x": 4,
+				"scale_y": 4
+			},
+			"type": "perlin"
+		},
+		{
+			"name": "normal_map_0",
+			"node_position": {
+				"x": 724.633789,
+				"y": 345.5
+			},
+			"parameters": {
+				"amount": 0.15,
+				"param0": 11,
+				"param1": 11,
+				"param2": 1,
+				"size": 4
+			},
+			"type": "normal_map"
+		},
+		{
+			"name": "blend_1",
+			"node_position": {
+				"x": 707.633789,
+				"y": -68
+			},
+			"parameters": {
+				"amount": 1,
+				"blend_type": 0
+			},
+			"type": "blend"
+		},
+		{
+			"name": "blend_0",
+			"node_position": {
+				"x": 222,
+				"y": 265.5
+			},
+			"parameters": {
+				"amount": 1,
+				"blend_type": 2
+			},
+			"type": "blend"
+		},
+		{
+			"name": "uniform_1",
+			"node_position": {
+				"x": 753,
+				"y": 116
+			},
+			"parameters": {
+				"color": {
+					"a": 1,
+					"b": 0,
+					"g": 0,
+					"r": 0,
+					"type": "Color"
+				}
+			},
+			"type": "uniform"
+		},
+		{
+			"name": "uniform_0",
+			"node_position": {
+				"x": 540,
+				"y": 234
+			},
+			"parameters": {
+				"color": {
+					"a": 1,
+					"b": 1,
+					"g": 1,
+					"r": 1,
+					"type": "Color"
+				}
+			},
+			"type": "uniform"
+		},
+		{
+			"name": "colorize_2",
+			"node_position": {
+				"x": 454.633789,
+				"y": -189.5
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0,
+							"r": 0.515625
+						},
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0.145455,
+							"r": 0.25
+						},
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0.445455,
+							"r": 0.515625
+						},
+						{
+							"a": 1,
+							"b": 0.013184,
+							"g": 0.013184,
+							"pos": 0.745455,
+							"r": 0.28125
+						},
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 1,
+							"r": 0.322917
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "colorize_1",
+			"node_position": {
+				"x": 461.329102,
+				"y": -116.699997
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0.034912,
+							"g": 0.129532,
+							"pos": 0,
+							"r": 0.203125
+						},
+						{
+							"a": 1,
+							"b": 0.038791,
+							"g": 0.074319,
+							"pos": 1,
+							"r": 0.114583
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "combine_0",
+			"node_position": {
+				"x": 942.329102,
+				"y": -55.5
+			},
+			"parameters": {
+				"color": {
+					"a": 1,
+					"b": 1,
+					"g": 1,
+					"r": 1,
+					"type": "Color"
+				},
+				"name": 0
+			},
+			"type": "combine"
+		},
+		{
+			"name": "perlin_0",
+			"node_position": {
+				"x": -20,
+				"y": 279.5
+			},
+			"parameters": {
+				"iterations": 6,
+				"persistence": 0.7,
+				"scale_x": 20,
+				"scale_y": 3
+			},
+			"type": "perlin"
+		}
+	],
+	"parameters": {
+
+	},
+	"type": "graph"
+}

--- a/addons/material_maker/examples/wooden_floor.ptex
+++ b/addons/material_maker/examples/wooden_floor.ptex
@@ -1,1 +1,274 @@
-{"connections":[{"from":"bricks_0","from_port":0,"to":"colorize_0","to_port":0},{"from":"colorize_0","from_port":0,"to":"blend_0","to_port":0},{"from":"blend_0","from_port":0,"to":"Material","to_port":0},{"from":"normal_map_0","from_port":0,"to":"Material","to_port":4},{"from":"blend_0","from_port":0,"to":"Material","to_port":2},{"from":"uniform_0","from_port":0,"to":"Material","to_port":1},{"from":"uniform_0","from_port":0,"to":"combine_0","to_port":0},{"from":"blend_0","from_port":0,"to":"combine_0","to_port":1},{"from":"transform_1","from_port":0,"to":"blend_0","to_port":1},{"from":"perlin_0","from_port":0,"to":"transform_1","to_port":0},{"from":"bricks_0","from_port":1,"to":"decompose_0","to_port":0},{"from":"decompose_0","from_port":0,"to":"transform_1","to_port":1},{"from":"decompose_0","from_port":1,"to":"transform_1","to_port":2},{"from":"blend_0","from_port":0,"to":"normal_map_0","to_port":0}],"label":"Graph","name":"490","node_position":{"x":0,"y":0},"nodes":[{"name":"colorize_0","node_position":{"x":524,"y":-100.75},"parameters":{"gradient":{"points":[{"a":1,"b":0,"g":0,"pos":0,"r":0},{"a":1,"b":0.213623,"g":0.391325,"pos":0.145455,"r":0.651042}],"type":"Gradient"}},"type":"colorize"},{"name":"normal_map_0","node_position":{"x":740,"y":135.25},"parameters":{"amount":0.3,"param0":11,"param1":0.2,"size":4},"type":"normal_map"},{"name":"uniform_0","node_position":{"x":781,"y":58},"parameters":{"color":{"a":1,"b":0,"g":0,"r":0,"type":"Color"}},"type":"uniform"},{"name":"Material","node_position":{"x":992,"y":42},"parameters":{"albedo_color":{"a":1,"b":1,"g":1,"r":1,"type":"Color"},"ao_light_affect":1,"depth_scale":1,"emission_energy":1,"metallic":1,"normal_scale":1,"resolution":1,"roughness":1,"size":11},"type":"material"},{"name":"combine_0","node_position":{"x":866,"y":-78},"parameters":{"color":{"a":1,"b":1,"g":1,"r":1,"type":"Color"},"name":0},"type":"combine"},{"name":"perlin_0","node_position":{"x":69,"y":81.25},"parameters":{"iterations":6,"persistence":0.75,"scale_x":4,"scale_y":20},"type":"perlin"},{"name":"decompose_0","node_position":{"x":97,"y":236},"parameters":{},"type":"decompose"},{"name":"bricks_0","node_position":{"x":79,"y":-124.75},"parameters":{"bevel":0,"columns":1,"mortar":0.02,"pattern":0,"repeat":1,"row_offset":0.5,"rows":10},"type":"bricks"},{"name":"transform_1","node_position":{"x":290,"y":120},"parameters":{"repeat":true,"rotate":0,"scale_x":1,"scale_y":1,"translate_x":1,"translate_y":1},"type":"transform"},{"name":"blend_0","node_position":{"x":492,"y":-13.75},"parameters":{"amount":0.554688,"blend_type":0},"type":"blend"}],"parameters":{},"type":"graph"}
+{
+	"connections": [
+		{
+			"from": "bricks_0",
+			"from_port": 0,
+			"to": "colorize_0",
+			"to_port": 0
+		},
+		{
+			"from": "colorize_0",
+			"from_port": 0,
+			"to": "blend_0",
+			"to_port": 0
+		},
+		{
+			"from": "blend_0",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 0
+		},
+		{
+			"from": "normal_map_0",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 4
+		},
+		{
+			"from": "blend_0",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 2
+		},
+		{
+			"from": "uniform_0",
+			"from_port": 0,
+			"to": "Material",
+			"to_port": 1
+		},
+		{
+			"from": "uniform_0",
+			"from_port": 0,
+			"to": "combine_0",
+			"to_port": 0
+		},
+		{
+			"from": "blend_0",
+			"from_port": 0,
+			"to": "combine_0",
+			"to_port": 1
+		},
+		{
+			"from": "transform_1",
+			"from_port": 0,
+			"to": "blend_0",
+			"to_port": 1
+		},
+		{
+			"from": "perlin_0",
+			"from_port": 0,
+			"to": "transform_1",
+			"to_port": 0
+		},
+		{
+			"from": "bricks_0",
+			"from_port": 1,
+			"to": "decompose_0",
+			"to_port": 0
+		},
+		{
+			"from": "decompose_0",
+			"from_port": 0,
+			"to": "transform_1",
+			"to_port": 1
+		},
+		{
+			"from": "decompose_0",
+			"from_port": 1,
+			"to": "transform_1",
+			"to_port": 2
+		},
+		{
+			"from": "blend_0",
+			"from_port": 0,
+			"to": "normal_map_0",
+			"to_port": 0
+		}
+	],
+	"label": "Graph",
+	"name": "490",
+	"node_position": {
+		"x": 0,
+		"y": 0
+	},
+	"nodes": [
+		{
+			"name": "colorize_0",
+			"node_position": {
+				"x": 524,
+				"y": -100.75
+			},
+			"parameters": {
+				"gradient": {
+					"points": [
+						{
+							"a": 1,
+							"b": 0,
+							"g": 0,
+							"pos": 0,
+							"r": 0
+						},
+						{
+							"a": 1,
+							"b": 0.213623,
+							"g": 0.391325,
+							"pos": 0.145455,
+							"r": 0.651042
+						}
+					],
+					"type": "Gradient"
+				}
+			},
+			"type": "colorize"
+		},
+		{
+			"name": "normal_map_0",
+			"node_position": {
+				"x": 740,
+				"y": 135.25
+			},
+			"parameters": {
+				"amount": 0.3,
+				"param0": 11,
+				"param1": 11,
+				"param2": 1,
+				"size": 4
+			},
+			"type": "normal_map"
+		},
+		{
+			"name": "uniform_0",
+			"node_position": {
+				"x": 781,
+				"y": 58
+			},
+			"parameters": {
+				"color": {
+					"a": 1,
+					"b": 0,
+					"g": 0,
+					"r": 0,
+					"type": "Color"
+				}
+			},
+			"type": "uniform"
+		},
+		{
+			"name": "Material",
+			"node_position": {
+				"x": 992,
+				"y": 42
+			},
+			"parameters": {
+				"albedo_color": {
+					"a": 1,
+					"b": 1,
+					"g": 1,
+					"r": 1,
+					"type": "Color"
+				},
+				"ao_light_affect": 1,
+				"depth_scale": 1,
+				"emission_energy": 1,
+				"metallic": 1,
+				"normal_scale": 1,
+				"resolution": 1,
+				"roughness": 1,
+				"size": 11
+			},
+			"type": "material"
+		},
+		{
+			"name": "combine_0",
+			"node_position": {
+				"x": 866,
+				"y": -78
+			},
+			"parameters": {
+				"color": {
+					"a": 1,
+					"b": 1,
+					"g": 1,
+					"r": 1,
+					"type": "Color"
+				},
+				"name": 0
+			},
+			"type": "combine"
+		},
+		{
+			"name": "perlin_0",
+			"node_position": {
+				"x": 69,
+				"y": 81.25
+			},
+			"parameters": {
+				"iterations": 6,
+				"persistence": 0.75,
+				"scale_x": 4,
+				"scale_y": 20
+			},
+			"type": "perlin"
+		},
+		{
+			"name": "decompose_0",
+			"node_position": {
+				"x": 97,
+				"y": 236
+			},
+			"parameters": {
+
+			},
+			"type": "decompose"
+		},
+		{
+			"name": "bricks_0",
+			"node_position": {
+				"x": 79,
+				"y": -124.75
+			},
+			"parameters": {
+				"bevel": 0,
+				"columns": 1,
+				"mortar": 0.02,
+				"pattern": 0,
+				"repeat": 1,
+				"row_offset": 0.5,
+				"rows": 10
+			},
+			"type": "bricks"
+		},
+		{
+			"name": "transform_1",
+			"node_position": {
+				"x": 290,
+				"y": 120
+			},
+			"parameters": {
+				"repeat": true,
+				"rotate": 0,
+				"scale_x": 1,
+				"scale_y": 1,
+				"translate_x": 1,
+				"translate_y": 1
+			},
+			"type": "transform"
+		},
+		{
+			"name": "blend_0",
+			"node_position": {
+				"x": 492,
+				"y": -13.75
+			},
+			"parameters": {
+				"amount": 0.554688,
+				"blend_type": 0
+			},
+			"type": "blend"
+		}
+	],
+	"parameters": {
+
+	},
+	"type": "graph"
+}

--- a/addons/material_maker/graph_edit.gd
+++ b/addons/material_maker/graph_edit.gd
@@ -199,7 +199,8 @@ func save_file(filename) -> void:
 	var data = top_generator.serialize()
 	var file = File.new()
 	if file.open(filename, File.WRITE) == OK:
-		file.store_string(to_json(data))
+		# Pretty-print the saved JSON for better diffs in version control
+		file.store_string(JSON.print(data, "\t", true))
 		file.close()
 	set_save_path(filename)
 	set_need_save(false)


### PR DESCRIPTION
This makes them about 15% larger on average, but we get better VCS diffs in exchange.

This doesn't break compatibility with existing materials.

All examples were resaved with this change. This also fixes the normal map filter texture sizes in all examples.