### PR TITLE
Increase the environments' radiance size to 512×512

### DIFF
--- a/addons/material_maker/preview/preview_3d.tscn
+++ b/addons/material_maker/preview/preview_3d.tscn
@@ -7,6 +7,7 @@
 
 [sub_resource type="PanoramaSky" id=1]
 resource_local_to_scene = true
+radiance_size = 4
 panorama = ExtResource( 2 )
 
 [sub_resource type="Environment" id=2]
@@ -31,6 +32,7 @@ tracks/0/keys = {
 
 [sub_resource type="PanoramaSky" id=4]
 resource_local_to_scene = true
+radiance_size = 4
 panorama = ExtResource( 4 )
 
 [sub_resource type="Environment" id=5]


### PR DESCRIPTION
This makes reflections more detailed, which is especially noticeable on smooth materials.