### PR TITLE
Disable ETC2 texture importing to speed up the initial project import

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -226,4 +226,5 @@ file_logging/enable_file_logging=true
 
 [rendering]
 
+vram_compression/import_etc2=false
 environment/default_environment="res://default_env.tres"


### PR DESCRIPTION
ETC2 is only used on mobile platforms with GLES3, which is poorly supported there anyway.