### PR TITLE
Add a project description

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -177,6 +177,7 @@ _global_script_class_icons={
 [application]
 
 config/name="Material Maker"
+config/description="An open source, extensible procedural material generation tool"
 run/main_scene="res://addons/material_maker/main_window.tscn"
 config/use_custom_user_dir=true
 config/custom_user_dir_name="material_maker"


### PR DESCRIPTION
In Godot 3.2, the description is displayed when hovering the project with the mouse in the project manager. The setting is backwards-compatible to Godot 3.1 (it won't break existing projects).

See also https://github.com/Orama-Interactive/Pixelorama/pull/48.